### PR TITLE
demo: fix splitEvenly remainder bug + missing test + stale doc

### DIFF
--- a/demo/docs/README.md
+++ b/demo/docs/README.md
@@ -4,17 +4,16 @@ Small math helpers used by the tip-pool router.
 
 ## API
 
-### `divideEvenly(total, n)`
+### `splitEvenly(total, n)`
 
-Returns an array of `n` integers that sum to `total`. Throws `RangeError` if
-`n <= 0` or `total < 0`.
+Returns an array of `n` integers that sum to `total`. Any leftover units after
+integer division are handed out one-per-bucket starting from the front.
+Throws `RangeError` if `n <= 0` or `total < 0`.
 
 ```ts
-import { divideEvenly } from "@x502/demo";
+import { splitEvenly } from "@x502/demo";
 
-divideEvenly(100, 4); // [25, 25, 25, 25]
+splitEvenly(100, 4); //  [25, 25, 25, 25]
+splitEvenly(10, 3);  //  [4, 3, 3]   ← sum is exactly 10
+splitEvenly(7, 4);   //  [2, 2, 2, 1]
 ```
-
-> ‼️ STALE (planted for x502 demo): the function was renamed to
-> `splitEvenly` but this doc still references the old name. The `docs_tests`
-> bounty rewards the PR that fixes this drift.

--- a/demo/src/split.ts
+++ b/demo/src/split.ts
@@ -1,9 +1,8 @@
 /**
  * Split an integer total evenly across `n` buckets.
  *
- * Returns an array of length `n` whose elements sum to `total`.
- * Used by the tip-pool router to divide micropayments without leaving wei
- * behind — every input cent must land in exactly one output bucket.
+ * Returns an array of length `n` whose elements sum to `total`. Any leftover
+ * units after integer division are distributed one-per-bucket from the front.
  */
 export function splitEvenly(total: number, n: number): number[] {
   if (!Number.isInteger(total) || !Number.isInteger(n)) {
@@ -12,9 +11,7 @@ export function splitEvenly(total: number, n: number): number[] {
   if (n <= 0) throw new RangeError("splitEvenly: n must be positive");
   if (total < 0) throw new RangeError("splitEvenly: total must be >= 0");
 
-  // BUG (planted for x502 demo): when `total` is not divisible by `n`,
-  // integer division loses the remainder and the returned slots no longer
-  // sum to `total`. Reporter's claim points at this.
-  const each = Math.floor(total / n);
-  return new Array(n).fill(each);
+  const base = Math.floor(total / n);
+  const remainder = total % n;
+  return Array.from({ length: n }, (_, i) => base + (i < remainder ? 1 : 0));
 }

--- a/demo/test/split.test.ts
+++ b/demo/test/split.test.ts
@@ -15,8 +15,16 @@ describe("splitEvenly", () => {
     expect(() => splitEvenly(-1, 3)).toThrow(RangeError);
   });
 
-  // GAP (planted for x502 demo): no test for the remainder case where
-  // total % n != 0. The bug in src/split.ts only surfaces here; the
-  // `docs_tests` bounty rewards the PR that adds this coverage.
-  // it.todo("preserves the remainder when total isn't divisible by n");
+  it("preserves the remainder when total isn't divisible by n", () => {
+    expect(splitEvenly(10, 3)).toEqual([4, 3, 3]);
+    expect(splitEvenly(10, 3).reduce((a, b) => a + b)).toBe(10);
+  });
+
+  it("hands out one extra to the first `total % n` buckets", () => {
+    expect(splitEvenly(7, 4)).toEqual([2, 2, 2, 1]);
+  });
+
+  it("returns zero-filled when total is 0", () => {
+    expect(splitEvenly(0, 5)).toEqual([0, 0, 0, 0, 0]);
+  });
 });


### PR DESCRIPTION
Fixes #2.

This PR is the demo subject for two simultaneous x502 bounty kinds — `fix` and `docs_tests` — against the `splitEvenly` helper in the demo project.

## What changed

| File | Bounty kind it satisfies | Change |
|---|---|---|
| `demo/src/split.ts` | `fix` (50 USDC) | distribute the `total % n` leftover one-per-bucket from the front so the array sums to exactly `total` |
| `demo/test/split.test.ts` | `docs_tests` (30 USDC) | add the missing remainder test, plus the front-distribution rule and the zero-total case |
| `demo/docs/README.md` | `docs_tests` (30 USDC) | rename `divideEvenly` → `splitEvenly` and update the example to reflect the fixed behaviour |

`claimId = keccak256(repoId, externalId, kind)` so `fix` and `docs_tests` produce different `claimId`s for the same PR — both can be paid out separately and the vault's one-shot fuse never collides.

## How it gets paid out

1. PR merges into the default branch.
2. Chainlink Functions DON pulls the PR via `chainlink/source.js`:
   - For `kind=fix`: confirms `merged === true`, base ref is the default branch, and the body matches `/(?:fixes|closes|resolves)\s+#\d+/i`.
   - For `kind=docs_tests`: confirms `merged === true` and that the file list under `/pulls/{n}/files` includes `test/`/`docs/` paths.
3. Coordinator submits the assembled bundle to `BountyVault.payout(...)`.

## x502 fixer binding

Below is the demo-persona binding used by the **"Carol"** fixer (ERC-8004 token id `103`, salt `0x...cafe`, recomputed from `keccak256(agentId || repoId || externalId || salt)`). The `kind=fix` and `kind=docs_tests` claims sent to the coordinator MUST reveal the matching `agentIdReveal` + `saltReveal`, and the verifier-agent's `ClaudePolicy` rejects any claim whose reveal does not produce this exact commitment.

```
agentId      : 103
repo         : skanislav/x502
externalId   : 3
salt         : 0x000000000000000000000000000000000000000000000000000000000000cafe
repoId       : 0x1492f36cb3574897acc481255a88821753bd0a710fd4c2d834c533af6913ca59
commitment   : 0xe5ed81793c6ec16c1094e2f8498d760cc9777ab40dd52b82d226c5d01aa63df0
```

Replace with your own values for a real claim using `pnpm exec tsx demo/scripts/derive-commitment.ts`.

<!-- x502-commitment:0xe5ed81793c6ec16c1094e2f8498d760cc9777ab40dd52b82d226c5d01aa63df0 -->

## Test plan

- [x] `splitEvenly(10, 3).reduce((a,b)=>a+b) === 10`
- [x] `splitEvenly(7, 4)` returns `[2, 2, 2, 1]`
- [x] `splitEvenly(0, 5)` returns `[0, 0, 0, 0, 0]`
- [x] Existing rejection cases still throw (negative total, non-positive n)
- [x] `demo/docs/README.md` references the current function name only

https://claude.ai/code/session_01SzY9Eg9Z391M15A49MZR5b