### PR TITLE
fix(demo): stabilize local runtime flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ contracts/broadcast/
 # Node
 node_modules/
 .pnpm-store/
+demo/.runtime/
+demo/scripts/skill-env.sh
+.playwright-cli/
+BRANCH-NOTES.md
 *.tsbuildinfo
 dist/
 build/

--- a/demo/scripts/seed.ts
+++ b/demo/scripts/seed.ts
@@ -25,7 +25,9 @@ import {
   type WalletClient,
   createPublicClient,
   createWalletClient,
+  parseEther,
   parseUnits,
+  toHex,
 } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { foundry } from "viem/chains";
@@ -185,6 +187,12 @@ async function main() {
     };
   });
 
+  const verifierGas = parseEther("1");
+  process.stdout.write("[seed] funding verifier wallets for EAS gas\n");
+  for (const v of verifiers) {
+    await setAnvilBalance(rpcUrl, v.address, verifierGas);
+  }
+
   process.stdout.write("[seed] registering verifier wallets\n");
   for (const v of verifiers) {
     await wallet.writeContract({
@@ -317,6 +325,22 @@ async function deployBytecode(
   const r = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!r.contractAddress) throw new Error(`deploy returned no address (tx=${tx})`);
   return r.contractAddress;
+}
+
+async function setAnvilBalance(rpcUrl: string, address: Address, balance: bigint): Promise<void> {
+  const r = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "anvil_setBalance",
+      params: [address, toHex(balance)],
+    }),
+  });
+  if (!r.ok) throw new Error(`anvil_setBalance HTTP ${r.status}`);
+  const body = (await r.json()) as { error?: { message?: string } };
+  if (body.error) throw new Error(`anvil_setBalance failed: ${body.error.message ?? "unknown"}`);
 }
 
 main().catch((e) => {

--- a/packages/coordinator/src/server.ts
+++ b/packages/coordinator/src/server.ts
@@ -1,5 +1,6 @@
 import { EventBus, Kind, type KindName, deriveClaimId } from "@x502/shared";
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { streamSSE } from "hono/streaming";
 import { type Address, type Hex, isAddress } from "viem";
 
@@ -89,6 +90,15 @@ export function buildCoordinator(opts: CoordinatorOptions): Coordinator {
   const events = new EventBus();
   const inbox = new AttestationInbox();
   const app = new Hono();
+
+  app.use(
+    "*",
+    cors({
+      origin: (origin) => origin || "*",
+      allowMethods: ["GET", "POST", "OPTIONS"],
+      allowHeaders: ["content-type"],
+    }),
+  );
 
   paymentGate.apply(app);
 

--- a/packages/coordinator/test/server.test.ts
+++ b/packages/coordinator/test/server.test.ts
@@ -78,6 +78,25 @@ describe("GET /health", () => {
   });
 });
 
+describe("CORS", () => {
+  it("allows the web demo to preflight claim submission", async () => {
+    const coord = makeCoord();
+    const r = await coord.app.request("/claim", {
+      method: "OPTIONS",
+      headers: {
+        origin: "http://127.0.0.1:3000",
+        "access-control-request-method": "POST",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    expect(r.status).toBe(204);
+    expect(r.headers.get("access-control-allow-origin")).toBe("http://127.0.0.1:3000");
+    expect(r.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(r.headers.get("access-control-allow-headers")).toContain("content-type");
+  });
+});
+
 describe("POST /claim — input validation", () => {
   it("rejects bad repoSlug", async () => {
     const coord = makeCoord();

--- a/packages/web/components/VerifierTheater.tsx
+++ b/packages/web/components/VerifierTheater.tsx
@@ -6,6 +6,11 @@ import { shortHash } from "../lib/format";
 
 type Status = "idle" | "attested";
 
+interface AgentSpec {
+  agentId: string;
+  address: string;
+}
+
 interface AgentColumn {
   agentId: string;
   attesterAddress: string;
@@ -34,7 +39,7 @@ export function VerifierTheater({
   claimId: string | undefined;
   /// (agentId, address) pairs from the demo runtime — used to map an
   /// observed attester back to the verifier identity for display.
-  agents: Array<{ agentId: string; address: string }>;
+  agents: AgentSpec[];
   /// Optional. Base URL for an attestation explorer (e.g. attest.org). When
   /// set, each attested column links to `${easExplorerBase}/${uid}`.
   easExplorerBase?: string;
@@ -104,13 +109,7 @@ export function VerifierTheater({
 
       <div className="grid grid-cols-3 gap-2">
         {agentSpecs.map((s) => {
-          const delta = deltas[s.address.toLowerCase()];
-          const agent: AgentColumn = {
-            agentId: s.agentId,
-            attesterAddress: s.address,
-            status: delta?.status ?? "idle",
-            uid: delta?.uid,
-          };
+          const agent = agentColumnFromSpec(s, deltas);
           return <AgentColumnCard key={s.agentId} agent={agent} explorer={easExplorerBase} />;
         })}
       </div>
@@ -123,6 +122,19 @@ export function VerifierTheater({
       )}
     </section>
   );
+}
+
+export function agentColumnFromSpec(
+  spec: AgentSpec,
+  deltas: Record<string, AttestationDelta>,
+): AgentColumn {
+  const delta = deltas[spec.address.toLowerCase()];
+  return {
+    agentId: spec.agentId,
+    attesterAddress: spec.address,
+    status: delta?.status ?? "idle",
+    uid: delta?.uid,
+  };
 }
 
 function AgentColumnCard({

--- a/packages/web/test/verifier-theater.test.tsx
+++ b/packages/web/test/verifier-theater.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { agentColumnFromSpec } from "../components/VerifierTheater";
+
+describe("agentColumnFromSpec", () => {
+  it("uses the current runtime verifier address", () => {
+    const column = agentColumnFromSpec(
+      {
+        agentId: "101",
+        address: "0xf571AcEe958B86FDD2be8A74e1CC041b58c9b48D",
+      },
+      {},
+    );
+
+    expect(column).toEqual({
+      agentId: "101",
+      attesterAddress: "0xf571AcEe958B86FDD2be8A74e1CC041b58c9b48D",
+      status: "idle",
+    });
+  });
+
+  it("preserves observed attestation state for unchanged verifier addresses", () => {
+    const column = agentColumnFromSpec(
+      {
+        agentId: "101",
+        address: "0xf571AcEe958B86FDD2be8A74e1CC041b58c9b48D",
+      },
+      {
+        "0xf571acee958b86fdd2be8a74e1cc041b58c9b48d": {
+          status: "attested",
+          uid: "0xabc",
+        },
+      },
+    );
+
+    expect(column).toEqual({
+      agentId: "101",
+      attesterAddress: "0xf571AcEe958B86FDD2be8A74e1CC041b58c9b48D",
+      status: "attested",
+      uid: "0xabc",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fund demo verifier wallets during seed so verifier EAS submissions have gas
- enable coordinator CORS for the web demo claim flow
- keep VerifierTheater columns in sync when runtime verifier addresses replace placeholders
- ignore local demo/runtime artifacts generated while running the demo

## Test Plan
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm test:ts
- [x] forge test --root contracts

## Notes
- This overlaps with PR 6 in packages/web/components/VerifierTheater.tsx, so whichever PR lands second may need a small conflict cleanup.