### PR TITLE
docs: add Base Sepolia demo runbook

### DIFF
--- a/docs/runbook-base-sepolia.md
+++ b/docs/runbook-base-sepolia.md
@@ -1,0 +1,524 @@
+# Base Sepolia Runbook
+
+This runbook explains how to prepare, run, and verify an x502 demo on Base
+Sepolia. Use `docs/sepolia-demo.md` for the latest known-good live proof and
+transaction hashes.
+
+## Known-Good Demo State
+
+Use these values when replaying or verifying the current live demo proof:
+
+| Item | Value |
+|---|---|
+| Network | Base Sepolia |
+| Chain ID | `84532` |
+| Repo | `skanislav/x502` |
+| Repo ID | `0x1492f36cb3574897acc481255a88821753bd0a710fd4c2d834c533af6913ca59` |
+| Current vault | `0x951395a508ddF903e8F766960c93D94120F30877` |
+| Fact receiver | `0x8e4f147B51F1013aFa72B9b84EAB67893890edE6` |
+| EAS | `0x4200000000000000000000000000000000000021` |
+| SchemaRegistry | `0x4200000000000000000000000000000000000020` |
+| x502 schema UID | `0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6` |
+| USDC | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| ERC-8004 registry | `0x8004A818BFB912233c491871b3d84c89A494BD9e` |
+| Trusted verifier agent | `5260` |
+| Trusted verifier wallet | `0x980abF154694Fe3Fea424eD095B04C6365E92F9b` |
+
+Do not use the older vault from `docs/base-sepolia-progress-2026-04-28.md`
+for the current EAS demo. That was a previous deployment.
+
+## Prerequisites
+
+1. Pull the latest `main`.
+2. Install dependencies.
+3. Make sure `.env` exists and contains the required live secrets.
+4. Make sure the deployer/coordinator/verifier wallet has Base Sepolia ETH.
+5. Make sure the repo owner wallet has enough Base Sepolia USDC.
+6. Make sure the Chainlink Functions subscription is funded with LINK.
+7. Make sure `gh`, `cast`, `forge`, and `pnpm` are available locally.
+
+Minimal environment needed:
+
+```sh
+BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+PRIVATE_KEY=<deployer-private-key>
+COORDINATOR_PRIVATE_KEY=<coordinator-private-key>
+VERIFIER_PRIVATE_KEY=<verifier-private-key>
+CHAINLINK_SUBSCRIPTION_ID=216
+USDC_ADDRESS=0x036CbD53842c5426634e7929541eC2318f3dCF7e
+```
+
+Never paste private keys into docs, PRs, terminal logs, or issue comments.
+
+## Preflight Checks
+
+Run from the repo root:
+
+```sh
+set -a
+source .env
+set +a
+
+cast chain-id --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast wallet address --private-key "$PRIVATE_KEY"
+cast balance "$(cast wallet address --private-key "$PRIVATE_KEY")" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$USDC_ADDRESS" "balanceOf(address)(uint256)" "$(cast wallet address --private-key "$PRIVATE_KEY")" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+Expected:
+
+- Chain ID is `84532`.
+- Wallet address is the intended deployer/repo owner.
+- ETH balance is enough for several testnet transactions.
+- USDC balance is enough for the intended vault deposit.
+
+## Register Or Verify The EAS Schema
+
+The x502 schema is:
+
+```text
+bytes32 claimId,bytes32 factHash,bool accept
+```
+
+Register it once per chain. The helper is idempotent:
+
+```sh
+set -a
+source .env
+set +a
+
+pnpm exec tsx demo/scripts/eas-register.ts \
+  --rpc "$BASE_SEPOLIA_RPC_URL" \
+  --scope-id PRIVATE_KEY \
+  --chain-id 84532
+```
+
+Expected UID:
+
+```text
+0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6
+```
+
+Verify it directly:
+
+```sh
+SCHEMA_UID=0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6
+
+cast call 0x4200000000000000000000000000000000000020 \
+  "getSchema(bytes32)((bytes32,address,bool,string))" \
+  "$SCHEMA_UID" \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+Expected schema string is `bytes32 claimId,bytes32 factHash,bool accept`.
+
+## Choose A Deployment Path
+
+There are two supported paths.
+
+### Path A: Reuse The Existing Fact Receiver
+
+Use this for the fastest demo setup. This was the path used for
+`docs/sepolia-demo.md`.
+
+You deploy only a fresh current `BountyVault` and reuse:
+
+```text
+GitHubFactReceiver=0x8e4f147B51F1013aFa72B9b84EAB67893890edE6
+```
+
+This avoids adding a new Chainlink Functions consumer.
+
+### Path B: Full Fresh Deploy
+
+Use this when the fact receiver source/config must change.
+
+The Foundry deploy script deploys both `GitHubFactReceiver` and `BountyVault`:
+
+```sh
+cd contracts
+
+set -a
+source ../.env
+set +a
+
+export X502_SCHEMA_UID=0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6
+export FUNCTIONS_SOURCE_PATH=../chainlink/source.js
+
+forge script script/Deploy.s.sol \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --broadcast
+```
+
+After a full fresh deploy, add the new fact receiver as a consumer on
+subscription `216`. Without this, `requestFact(...)` will fail or never
+fulfill.
+
+## Deploy A Fresh Vault While Reusing The Fact Receiver
+
+Use this command for Path A:
+
+```sh
+cd contracts
+
+set -a
+source ../.env
+set +a
+
+SCHEMA_UID=0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6
+FACT_PROVIDER=0x8e4f147B51F1013aFa72B9b84EAB67893890edE6
+REGISTRY=0x8004A818BFB912233c491871b3d84c89A494BD9e
+EAS=0x4200000000000000000000000000000000000021
+
+forge create src/BountyVault.sol:BountyVault \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --private-key "$PRIVATE_KEY" \
+  --broadcast \
+  --constructor-args \
+  "$USDC_ADDRESS" \
+  "$REGISTRY" \
+  "$FACT_PROVIDER" \
+  "$EAS" \
+  "$SCHEMA_UID"
+```
+
+Record:
+
+- New vault address
+- Deployment transaction hash
+- Block number
+
+Immediately verify the immutable wiring:
+
+```sh
+VAULT=<new-vault-address>
+
+cast call "$VAULT" "usdc()(address)" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "agentRegistry()(address)" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "factProvider()(address)" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "eas()(address)" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "schemaUID()(bytes32)" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+Expected values are the addresses listed in the known-good table.
+
+## Configure The Repo
+
+For `skanislav/x502`, use:
+
+```sh
+REPO_ID=0x1492f36cb3574897acc481255a88821753bd0a710fd4c2d834c533af6913ca59
+TRUSTED_AGENT=5260
+THRESHOLD=1
+REPORT_PRICE=50000
+TRIAGE_PRICE=20000
+FIX_PRICE=500000
+DOCS_TESTS_PRICE=300000
+OUTCOME_FEE=1000
+
+cast send "$VAULT" \
+  "configureRepo(bytes32,uint256[],uint8,(uint256,uint256,uint256,uint256),uint256)" \
+  "$REPO_ID" \
+  "[$TRUSTED_AGENT]" \
+  "$THRESHOLD" \
+  "($REPORT_PRICE,$TRIAGE_PRICE,$FIX_PRICE,$DOCS_TESTS_PRICE)" \
+  "$OUTCOME_FEE" \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --private-key "$PRIVATE_KEY"
+```
+
+Verify:
+
+```sh
+cast call "$VAULT" "repoOwnerOf(bytes32)(address)" "$REPO_ID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "trustedAgentsOf(bytes32)(uint256[])" "$REPO_ID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "thresholdOf(bytes32)(uint8)" "$REPO_ID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "priceOf(bytes32,uint8)(uint256)" "$REPO_ID" 0 --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "outcomeFeeOf(bytes32)(uint256)" "$REPO_ID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+## Fund The Vault
+
+Approve and deposit USDC:
+
+```sh
+DEPOSIT=2000000
+
+cast send "$USDC_ADDRESS" \
+  "approve(address,uint256)" \
+  "$VAULT" \
+  "$DEPOSIT" \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --private-key "$PRIVATE_KEY"
+
+cast send "$VAULT" \
+  "deposit(bytes32,uint256)" \
+  "$REPO_ID" \
+  "$DEPOSIT" \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --private-key "$PRIVATE_KEY"
+```
+
+Verify vault accounting and token balance:
+
+```sh
+cast call "$VAULT" "balanceOf(bytes32)(uint256)" "$REPO_ID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$USDC_ADDRESS" "balanceOf(address)(uint256)" "$VAULT" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+Both should equal the deposited amount before any payout.
+
+## Run The Coordinator
+
+Start the coordinator with live Base Sepolia env:
+
+```sh
+set -a
+source .env
+set +a
+
+export RPC_URL="$BASE_SEPOLIA_RPC_URL"
+export COORDINATOR_PORT=8787
+export COORDINATOR_CHAIN_ID=84532
+export VAULT_ADDRESS="$VAULT"
+export FACT_PROVIDER_ADDRESS=0x8e4f147B51F1013aFa72B9b84EAB67893890edE6
+export EAS_ADDRESS=0x4200000000000000000000000000000000000021
+export X502_SCHEMA_UID=0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6
+export COORDINATOR_REPO=skanislav/x502
+export COORDINATOR_THRESHOLD=1
+export COORDINATOR_TRUSTED_AGENT_IDS=5260
+export COORDINATOR_TRUSTED_ATTESTERS=0x980abF154694Fe3Fea424eD095B04C6365E92F9b
+export COORDINATOR_FACT_TIMEOUT_MS=300000
+export COORDINATOR_ATTESTATION_TIMEOUT_MS=900000
+export ONECLAW_MODE=local
+export COORDINATOR_ONECLAW_SCOPE_ID=COORDINATOR_PRIVATE_KEY
+
+pnpm exec tsx packages/coordinator/src/main.ts
+```
+
+Health check:
+
+```sh
+curl -sS http://127.0.0.1:8787/health
+```
+
+## Submit A Claim
+
+For the report demo against issue `#2`:
+
+```sh
+curl -sS -X POST http://127.0.0.1:8787/claim \
+  -H 'content-type: application/json' \
+  --data '{
+    "repoSlug": "skanislav/x502",
+    "externalId": "2",
+    "kind": "report",
+    "recipient": "0xc2603c34e6C50E1389a008764A05Ac24919Bc3B3",
+    "agentIdReveal": "101",
+    "saltReveal": "0x000000000000000000000000000000000000000000000000000000000000beef"
+  }'
+```
+
+Poll:
+
+```sh
+CLAIM=<claim-id>
+
+curl -sS "http://127.0.0.1:8787/payout/$CLAIM"
+pnpm exec tsx demo/scripts/x502.ts pending \
+  --coordinator http://127.0.0.1:8787 \
+  --agent-id 5260
+```
+
+When `pending` returns a `factHash`, move to attestation.
+
+## Publish The Verifier Attestation
+
+Use the `factHash` returned by `pending`:
+
+```sh
+CLAIM=<claim-id>
+FACT_HASH=<fact-hash-from-pending>
+
+set -a
+source .env
+set +a
+
+pnpm exec tsx demo/scripts/x502.ts attest \
+  --rpc "$BASE_SEPOLIA_RPC_URL" \
+  --eas 0x4200000000000000000000000000000000000021 \
+  --schema 0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6 \
+  --scope-id VERIFIER_PRIVATE_KEY \
+  --chain-id 84532 \
+  --claim-id "$CLAIM" \
+  --fact-hash "$FACT_HASH"
+```
+
+Record:
+
+- EAS attestation UID
+- EAS attestation tx hash
+
+## Wait For Coordinator Payout
+
+If the coordinator watcher observes the attestation, it should submit
+`BountyVault.payout(...)` automatically.
+
+Poll:
+
+```sh
+curl -sS "http://127.0.0.1:8787/payout/$CLAIM"
+cast call "$VAULT" "isPaid(bytes32)(bool)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+Expected terminal state:
+
+- Coordinator poll returns `paid`, or
+- `isPaid(claimId)` returns `true`.
+
+## Permissionless Payout Fallback
+
+If EAS attestation exists but the coordinator does not count it, use the
+permissionless vault path. First simulate the call:
+
+```sh
+RECIPIENT=0xc2603c34e6C50E1389a008764A05Ac24919Bc3B3
+EXTERNAL_ID=2
+KIND=0
+DEADLINE=<deadline-from-pending>
+UID=<eas-attestation-uid>
+
+cast call "$VAULT" \
+  "payout(bytes32,uint256,uint8,address,uint256,bytes32,bytes32[])" \
+  "$REPO_ID" \
+  "$EXTERNAL_ID" \
+  "$KIND" \
+  "$RECIPIENT" \
+  "$DEADLINE" \
+  "$FACT_HASH" \
+  "[$UID]" \
+  --from "$(cast wallet address --private-key "$PRIVATE_KEY")" \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+Only broadcast if the simulation returns `0x`:
+
+```sh
+cast send "$VAULT" \
+  "payout(bytes32,uint256,uint8,address,uint256,bytes32,bytes32[])" \
+  "$REPO_ID" \
+  "$EXTERNAL_ID" \
+  "$KIND" \
+  "$RECIPIENT" \
+  "$DEADLINE" \
+  "$FACT_HASH" \
+  "[$UID]" \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --private-key "$PRIVATE_KEY"
+```
+
+Record the payout tx hash.
+
+## Final Verification
+
+Verify the settlement:
+
+```sh
+ATTESTER=0x980abF154694Fe3Fea424eD095B04C6365E92F9b
+
+cast call "$VAULT" "isPaid(bytes32)(bool)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "balanceOf(bytes32)(uint256)" "$REPO_ID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$USDC_ADDRESS" "balanceOf(address)(uint256)" "$VAULT" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$USDC_ADDRESS" "balanceOf(address)(uint256)" "$RECIPIENT" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$USDC_ADDRESS" "balanceOf(address)(uint256)" "$ATTESTER" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+For a single report payout with one verifier:
+
+- Repo balance decreases by `50000` USDC units.
+- Recipient receives `49000` USDC units.
+- Verifier receives `1000` USDC units.
+- `isPaid(claimId)` becomes `true`.
+
+## What To Capture For Submission
+
+For every live run, capture:
+
+- Network and chain ID
+- Vault address
+- Fact receiver address
+- Schema UID
+- Claim ID
+- Chainlink request and fulfill tx hashes
+- EAS attestation UID and tx hash
+- Payout tx hash
+- Final `isPaid(claimId)` value
+- Final recipient and verifier USDC balances
+- Any caveat, especially whether payout was coordinator-driven or
+  permissionless fallback
+
+Update `docs/sepolia-demo.md` if the live proof changes.
+
+## Troubleshooting
+
+### Schema is missing
+
+Run `demo/scripts/eas-register.ts` again. It is idempotent.
+
+### `forge create` dry-runs instead of broadcasting
+
+Add `--broadcast`.
+
+### `requestFact(...)` reverts
+
+Check:
+
+- `GitHubFactReceiver.authorizer()`
+- `GitHubFactReceiver.config()`
+- Chainlink subscription has LINK
+- Receiver is added as a consumer if it is a new receiver
+
+### `pending` never returns a fact hash
+
+Check:
+
+```sh
+cast call "$FACT_PROVIDER_ADDRESS" "requestIdOf(bytes32)(bytes32)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$FACT_PROVIDER_ADDRESS" "getFact(bytes32)(bool,bytes)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+If `getFact` is ready but the coordinator is stale, restart the coordinator
+and resubmit the same claim. The claim ID is deterministic.
+
+### Attestation exists but coordinator shows `sigs=0`
+
+Verify the EAS attestation:
+
+```sh
+cast call 0x4200000000000000000000000000000000000021 \
+  "getAttestation(bytes32)((bytes32,bytes32,uint64,uint64,uint64,bytes32,address,address,bool,bytes))" \
+  "$UID" \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
+
+Check that:
+
+- Schema equals `X502_SCHEMA_UID`
+- Attester equals the trusted wallet for agent `5260`
+- Data contains the same `claimId`
+- Data contains the same `factHash`
+- Final bool is `true`
+
+If all checks pass, use the permissionless payout fallback.
+
+### Payout simulation reverts
+
+Do not broadcast. Check:
+
+- `isPaid(claimId)` is still `false`
+- Fact is ready
+- `keccak256(factBlob)` equals the attested `factHash`
+- `ghAuthorBinding` equals the payout recipient
+- Agent `5260` resolves to the attester wallet in ERC-8004
+- Vault has enough repo balance
+- Deadline has not expired

--- a/docs/sepolia-demo.md
+++ b/docs/sepolia-demo.md
@@ -1,0 +1,192 @@
+# Base Sepolia Demo Proof - 2026-05-03
+
+This document captures the live Base Sepolia run used to prove the current
+EAS-based x502 settlement path. It is the current demo proof; the older
+`docs/base-sepolia-progress-2026-04-28.md` describes a previous pre-EAS vault.
+
+## Summary
+
+- Network: Base Sepolia
+- Chain ID: `84532`
+- Repo: `skanislav/x502`
+- Repo ID: `0x1492f36cb3574897acc481255a88821753bd0a710fd4c2d834c533af6913ca59`
+- Claim kind: `report` (`0`)
+- GitHub external ID: issue `#2`
+- Claim ID: `0x132167063b9157ad05743480c326f1fe594001c9ae119d3460af0e9d55153847`
+- Claimant / payout recipient: `0xc2603c34e6C50E1389a008764A05Ac24919Bc3B3`
+- Repo owner / deployer / live verifier wallet: `0x980abF154694Fe3Fea424eD095B04C6365E92F9b`
+- Trusted verifier ERC-8004 agent ID: `5260`
+
+## Contracts
+
+| Contract / service | Address / ID | Notes |
+|---|---|---|
+| Current `BountyVault` | `0x951395a508ddF903e8F766960c93D94120F30877` | Fresh current-code vault deployed for this EAS demo |
+| Reused `GitHubFactReceiver` | `0x8e4f147B51F1013aFa72B9b84EAB67893890edE6` | Existing Chainlink Functions consumer |
+| EAS | `0x4200000000000000000000000000000000000021` | Canonical Base Sepolia/Superchain predeploy |
+| EAS SchemaRegistry | `0x4200000000000000000000000000000000000020` | Used to register the x502 attestation schema |
+| x502 schema UID | `0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6` | Schema string: `bytes32 claimId,bytes32 factHash,bool accept` |
+| Base Sepolia USDC | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` | 6 decimals |
+| ERC-8004 Identity Registry | `0x8004A818BFB912233c491871b3d84c89A494BD9e` | Agent `5260` resolves to verifier wallet |
+| Chainlink Functions Router | `0xf9B8fc078197181C841c296C876945aaa425B278` | Router used by the reused receiver |
+| Chainlink Functions subscription | `216` | Existing subscription used by receiver |
+
+## Current Vault Wiring
+
+Read from `0x951395a508ddF903e8F766960c93D94120F30877` after deployment:
+
+| Getter | Value |
+|---|---|
+| `usdc()` | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| `agentRegistry()` | `0x8004A818BFB912233c491871b3d84c89A494BD9e` |
+| `factProvider()` | `0x8e4f147B51F1013aFa72B9b84EAB67893890edE6` |
+| `eas()` | `0x4200000000000000000000000000000000000021` |
+| `schemaUID()` | `0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6` |
+
+Repo config for `skanislav/x502`:
+
+| Field | Value |
+|---|---|
+| Owner | `0x980abF154694Fe3Fea424eD095B04C6365E92F9b` |
+| Trusted agents | `[5260]` |
+| Threshold | `1` |
+| Report price | `50000` USDC units (`0.05 USDC`) |
+| Triage price | `20000` USDC units (`0.02 USDC`) |
+| Fix price | `500000` USDC units (`0.5 USDC`) |
+| Docs/tests price | `300000` USDC units (`0.3 USDC`) |
+| Outcome fee per verifier | `1000` USDC units (`0.001 USDC`) |
+| Initial deposit | `2000000` USDC units (`2 USDC`) |
+
+## Transaction Ledger
+
+All transactions below were checked against Base Sepolia. `status = 1` means
+the transaction succeeded.
+
+| Step | Tx hash | Block | Status | Gas used | Notes |
+|---|---|---:|---:|---:|---|
+| Register x502 EAS schema | `0x3e8a6081e3b32eca33d97600ccf31449fc337e5d67bdaea4aa762cfce1d1a9c2` | `41024663` | `1` | `144307` | Registered schema UID `0x5dcd6b...65e3c6` |
+| Deploy current `BountyVault` | `0x013f1a3d4105b05e16c253d45d7f87f879f9e2ab0c8271fae627d7a4b082d91a` | `41024680` | `1` | `1303568` | Vault at `0x951395a5...20F30877` |
+| Configure repo | `0x24da43459c7e83ee4f3cf356d6e01e5947307be443f9756573069d99c0600090` | `41024707` | `1` | `247025` | Trusted agent `[5260]`, threshold `1` |
+| Approve `2 USDC` | `0x967f89cb3df8b3146ed2d268e8b6132a17e6cc9cf67db7ae0f14fced6a178ac7` | `41024733` | `1` | `55437` | USDC allowance from deployer to vault |
+| Deposit `2 USDC` | `0xef6ac0e5621ba599c73ad7d62b333b75ef808a4b02eb17fcea58638885d447fd` | `41024737` | `1` | `92649` | Vault internal repo balance became `2000000` |
+| Chainlink fact request 1 | `0x5a77e79d2aabaf61f068af1a8e77bffc686c36a8735cf97e1f1406088672ed61` | `41024816` | `1` | `806798` | Request ID `0xbcc25880...bf528` |
+| Chainlink fact fulfill 1 | `0x47ce4587e6650f621741e984b7fea69b92eaf373c87fe1549221ca6dbaf5378c` | `41024821` | `1` | `296108` | Stored fact for claim ID |
+| Chainlink fact request 2 | `0x26d7f4d0c78651e4405b7fdb86cdc2beb7e40229afa771ac09fe6b4b555281ce` | `41024868` | `1` | `806798` | Request ID `0xaa6ddb3f...656331`; created after coordinator restart |
+| Chainlink fact fulfill 2 | `0x5fcd96a986e3b9406c8778f3b5a2334963270204aef7137d1475804cd632a357` | `41024872` | `1` | `236384` | Latest `requestIdOf(claimId)` points here |
+| Publish EAS attestation | `0x83168e5e3cc84d5bb819cfa59da64a2a685f3e91857b5f438807b86ac8eccd07` | `41024875` | `1` | `239767` | Attestation UID `0xb631d99e...13947b4d` |
+| Vault payout | `0x8dda84901de003747a6966d53f71f67be6ea4c9bdb78fdbf798bd4c04af97193` | `41024924` | `1` | `188843` | Paid claimant and verifier outcome fee |
+
+Useful explorer links:
+
+- Payout tx: `https://sepolia.basescan.org/tx/0x8dda84901de003747a6966d53f71f67be6ea4c9bdb78fdbf798bd4c04af97193`
+- EAS attestation: `https://base-sepolia.easscan.org/attestation/view/0xb631d99e432b8def12d9cba441cd87b0e14e34b978f393f76fac8c9e13947b4d`
+- Vault address: `https://sepolia.basescan.org/address/0x951395a508ddF903e8F766960c93D94120F30877`
+- Fact receiver address: `https://sepolia.basescan.org/address/0x8e4f147B51F1013aFa72B9b84EAB67893890edE6`
+
+## Claim Fact
+
+Current receiver state:
+
+- `requestIdOf(claimId)`: `0xaa6ddb3f531b326e545db1953d249c02d81292ef6a31201dcf2f1e9cda656331`
+- `getFact(claimId).ready`: `true`
+- Fact hash used for the final attestation and payout:
+  `0xbae70480321e51abc32665085966a6f7c44fc7bf4cbda31849af9c9eccb3d0bc`
+
+Decoded fact blob:
+
+| Field | Value |
+|---|---|
+| `status` | `1` |
+| `mergedBlock` | `0` |
+| `labelMask` | `0x0000000000000000000000000000000000000000000000000000000000000001` |
+| `ghAuthorBinding` | `0xc2603c34e6C50E1389a008764A05Ac24919Bc3B3` |
+
+Raw fact blob:
+
+```text
+0x0000000000000000000000000000000000000000000000000000000000000001
+  0000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000001
+  000000000000000000000000c2603c34e6c50e1389a008764a05ac24919bc3b3
+```
+
+## EAS Attestation
+
+- UID: `0xb631d99e432b8def12d9cba441cd87b0e14e34b978f393f76fac8c9e13947b4d`
+- Schema: `0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6`
+- Attester: `0x980abF154694Fe3Fea424eD095B04C6365E92F9b`
+- Recipient in EAS attestation: `0x0000000000000000000000000000000000000000`
+- Revocable: `true`
+- Encoded attestation data:
+
+```text
+0x132167063b9157ad05743480c326f1fe594001c9ae119d3460af0e9d55153847
+  bae70480321e51abc32665085966a6f7c44fc7bf4cbda31849af9c9eccb3d0bc
+  0000000000000000000000000000000000000000000000000000000000000001
+```
+
+The encoded tuple is `(claimId, factHash, accept=true)`.
+
+## Final On-Chain State
+
+Verified after payout:
+
+| Check | Value |
+|---|---|
+| `BountyVault.isPaid(claimId)` | `true` |
+| Vault internal repo balance | `1950000` USDC units (`1.95 USDC`) |
+| Vault USDC token balance | `1950000` USDC units (`1.95 USDC`) |
+| Claimant USDC balance after run | `49000` USDC units (`0.049 USDC`) |
+| Verifier/deployer USDC balance after run | `8001000` USDC units (`8.001 USDC`) |
+
+The payout transaction transferred:
+
+- `49000` USDC units (`0.049 USDC`) to
+  `0xc2603c34e6C50E1389a008764A05Ac24919Bc3B3`
+- `1000` USDC units (`0.001 USDC`) to
+  `0x980abF154694Fe3Fea424eD095B04C6365E92F9b`
+
+## Demo Caveat
+
+The live coordinator opened the claim and requested the Chainlink fact, but
+its EAS watcher did not observe the live EAS attestation log in time. The
+settlement was completed by calling the vault's permissionless `payout(...)`
+directly with the valid attestation UID after a successful `cast call`
+simulation.
+
+This still proves the live Base Sepolia contract path:
+
+1. EAS schema registered on Base Sepolia.
+2. Current vault deployed and configured with EAS + SchemaRegistry-derived UID.
+3. Chainlink Functions fact stored on the reused receiver.
+4. Verifier wallet published an EAS attestation under the x502 schema.
+5. `BountyVault.payout(...)` validated the fact, schema, attestation data,
+   trusted ERC-8004 agent wallet, recipient binding, and transferred USDC.
+
+For a staged UI walkthrough, use the local demo UI for the animated flow and
+then show the Base Sepolia transaction hashes above as real-network proof.
+
+## Verification Commands
+
+Use these commands from the repo root. They assume `.env` contains
+`BASE_SEPOLIA_RPC_URL`. Do not print private keys.
+
+```sh
+VAULT=0x951395a508ddF903e8F766960c93D94120F30877
+FACT=0x8e4f147B51F1013aFa72B9b84EAB67893890edE6
+EAS=0x4200000000000000000000000000000000000021
+USDC=0x036CbD53842c5426634e7929541eC2318f3dCF7e
+REPO_ID=0x1492f36cb3574897acc481255a88821753bd0a710fd4c2d834c533af6913ca59
+CLAIM=0x132167063b9157ad05743480c326f1fe594001c9ae119d3460af0e9d55153847
+UID=0xb631d99e432b8def12d9cba441cd87b0e14e34b978f393f76fac8c9e13947b4d
+RECIPIENT=0xc2603c34e6C50E1389a008764A05Ac24919Bc3B3
+ATTESTER=0x980abF154694Fe3Fea424eD095B04C6365E92F9b
+
+cast call "$VAULT" "isPaid(bytes32)(bool)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$VAULT" "balanceOf(bytes32)(uint256)" "$REPO_ID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$FACT" "requestIdOf(bytes32)(bytes32)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$FACT" "getFact(bytes32)(bool,bytes)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$EAS" "getAttestation(bytes32)((bytes32,bytes32,uint64,uint64,uint64,bytes32,address,address,bool,bytes))" "$UID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$USDC" "balanceOf(address)(uint256)" "$RECIPIENT" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast call "$USDC" "balanceOf(address)(uint256)" "$ATTESTER" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```


### PR DESCRIPTION
## Summary

Adds Base Sepolia documentation for the current live demo proof and a repeatable operator runbook.

- adds `docs/sepolia-demo.md` with the current contract addresses, schema UID, transaction ledger, Chainlink fact details, EAS attestation UID, payout tx, final balances, explorer links, and the coordinator watcher caveat
- adds `docs/runbook-base-sepolia.md` with preflight checks, schema registration, deployment options, repo configuration, vault funding, coordinator startup, claim submission, verifier attestation, permissionless payout fallback, final verification, and troubleshooting

## Verification

- `git diff --cached --check`
- scanned the docs for TODO/TBD placeholders and private-key-shaped values

## Notes

`contracts/broadcast/` remains untracked local generated output and is intentionally excluded from this PR.