### PR TITLE
fix: make EAS demo log handling resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,91 @@
+# x502
+
+x502 is a demo protocol for paying AI agents and human operators for
+verifiable GitHub outcomes. A repo owner funds a `BountyVault`, a claimant
+submits a GitHub issue or PR outcome, Chainlink Functions stores the GitHub
+fact, verifier agents publish EAS attestations, and the vault pays USDC after
+the threshold is met.
+
+## Demo Quick Start
+
+Run the local end-to-end demo:
+
+```sh
+pnpm install
+pnpm demo
+```
+
+The demo starts:
+
+- anvil on `http://127.0.0.1:8545`
+- coordinator on `http://127.0.0.1:8787`
+- web UI on `http://127.0.0.1:3000/?mode=demo`
+- local Chainlink Functions simulator
+
+Then load verifier keys and run the verifier skill from Claude Code:
+
+```sh
+source demo/scripts/skill-env.sh
+claude
+```
+
+Inside Claude Code:
+
+```text
+> /x502-verify as agent 101
+> /x502-verify as agent 102
+```
+
+The UI should advance through claim, fact, EAS attestation, and payout.
+
+## Live Base Sepolia Proof
+
+The current live proof is documented in:
+
+- `docs/sepolia-demo.md`
+- `docs/runbook-base-sepolia.md`
+
+Known-good live Base Sepolia artifacts:
+
+| Item | Value |
+|---|---|
+| Chain ID | `84532` |
+| Vault | `0x951395a508ddF903e8F766960c93D94120F30877` |
+| Fact receiver | `0x8e4f147B51F1013aFa72B9b84EAB67893890edE6` |
+| EAS | `0x4200000000000000000000000000000000000021` |
+| Schema UID | `0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6` |
+| EAS attestation UID | `0xb631d99e432b8def12d9cba441cd87b0e14e34b978f393f76fac8c9e13947b4d` |
+| EAS attestation tx | `0x83168e5e3cc84d5bb819cfa59da64a2a685f3e91857b5f438807b86ac8eccd07` |
+| Payout tx | `0x8dda84901de003747a6966d53f71f67be6ea4c9bdb78fdbf798bd4c04af97193` |
+
+Useful links:
+
+- EAS attestation:
+  `https://base-sepolia.easscan.org/attestation/view/0xb631d99e432b8def12d9cba441cd87b0e14e34b978f393f76fac8c9e13947b4d`
+- Payout tx:
+  `https://sepolia.basescan.org/tx/0x8dda84901de003747a6966d53f71f67be6ea4c9bdb78fdbf798bd4c04af97193`
+- Vault:
+  `https://sepolia.basescan.org/address/0x951395a508ddF903e8F766960c93D94120F30877`
+
+## Demo Recording Checklist
+
+Record a 2-4 minute video:
+
+1. Open the web UI at `http://127.0.0.1:3000/?mode=demo`.
+2. Show a GitHub claim being submitted.
+3. Show the Chainlink fact becoming ready.
+4. Run the verifier skill and show EAS attestations landing.
+5. Show the payout state changing to paid.
+6. Show the live Base Sepolia EAS attestation and payout transaction links.
+
+For the hackathon recording, use the local UI for the smooth walkthrough and
+the Base Sepolia links above as real-network proof.
+
+## Development
+
+```sh
+pnpm lint
+pnpm typecheck
+pnpm test:ts
+forge test --root contracts
+```

--- a/docs/runbook-base-sepolia.md
+++ b/docs/runbook-base-sepolia.md
@@ -296,6 +296,11 @@ export COORDINATOR_ONECLAW_SCOPE_ID=COORDINATOR_PRIVATE_KEY
 pnpm exec tsx packages/coordinator/src/main.ts
 ```
 
+On startup, the coordinator watches new EAS `Attested` events and also
+backfills the latest `500` EAS blocks for the configured schema. This lets a
+restarted coordinator recover attestations that landed shortly before the
+subscription was ready.
+
 Health check:
 
 ```sh
@@ -358,6 +363,11 @@ Record:
 
 - EAS attestation UID
 - EAS attestation tx hash
+- The raw EAS `Attested` event log from the receipt:
+
+```sh
+cast receipt <eas-attestation-tx-hash> --rpc-url "$BASE_SEPOLIA_RPC_URL"
+```
 
 ## Wait For Coordinator Payout
 
@@ -454,6 +464,7 @@ For every live run, capture:
 - Payout tx hash
 - Final `isPaid(claimId)` value
 - Final recipient and verifier USDC balances
+- Raw EAS `Attested` event log from the attestation tx receipt
 - Any caveat, especially whether payout was coordinator-driven or
   permissionless fallback
 
@@ -491,6 +502,10 @@ If `getFact` is ready but the coordinator is stale, restart the coordinator
 and resubmit the same claim. The claim ID is deterministic.
 
 ### Attestation exists but coordinator shows `sigs=0`
+
+Current coordinator builds backfill the most recent `500` EAS blocks on
+startup. If the attestation landed recently, restart the coordinator and
+resubmit the deterministic claim before falling back to a manual payout.
 
 Verify the EAS attestation:
 

--- a/docs/sepolia-demo.md
+++ b/docs/sepolia-demo.md
@@ -127,6 +127,46 @@ Raw fact blob:
 
 The encoded tuple is `(claimId, factHash, accept=true)`.
 
+## Live EAS Event Log
+
+The attestation transaction emitted the real Base Sepolia EAS `Attested`
+event. This is the raw receipt log decoded from transaction
+`0x83168e5e3cc84d5bb819cfa59da64a2a685f3e91857b5f438807b86ac8eccd07`.
+
+| Field | Value |
+|---|---|
+| Block | `41024875` |
+| Timestamp | `2026-05-03 14:20:38 UTC` |
+| Log index | `0x114` |
+| EAS address | `0x4200000000000000000000000000000000000021` |
+| Event signature | `Attested(address,address,bytes32,bytes32)` |
+| Topic 0 | `0x8bf46bf4cfd674fa735a3d63ec1c9ad4153f033c290341f3a588b75685141b35` |
+| Indexed recipient | `0x0000000000000000000000000000000000000000` |
+| Indexed attester | `0x980abF154694Fe3Fea424eD095B04C6365E92F9b` |
+| Indexed schema | `0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6` |
+| Data / UID | `0xb631d99e432b8def12d9cba441cd87b0e14e34b978f393f76fac8c9e13947b4d` |
+
+Raw log:
+
+```json
+{
+  "address": "0x4200000000000000000000000000000000000021",
+  "topics": [
+    "0x8bf46bf4cfd674fa735a3d63ec1c9ad4153f033c290341f3a588b75685141b35",
+    "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "0x000000000000000000000000980abf154694fe3fea424ed095b04c6365e92f9b",
+    "0x5dcd6b7851d582fe235f915024912fe525f2fc63cd477511182213c1b065e3c6"
+  ],
+  "data": "0xb631d99e432b8def12d9cba441cd87b0e14e34b978f393f76fac8c9e13947b4d",
+  "blockNumber": "0x271fd6b",
+  "blockTimestamp": "0x69f759b6",
+  "transactionHash": "0x83168e5e3cc84d5bb819cfa59da64a2a685f3e91857b5f438807b86ac8eccd07",
+  "transactionIndex": "0xa",
+  "logIndex": "0x114",
+  "removed": false
+}
+```
+
 ## Final On-Chain State
 
 Verified after payout:
@@ -148,11 +188,16 @@ The payout transaction transferred:
 
 ## Demo Caveat
 
-The live coordinator opened the claim and requested the Chainlink fact, but
-its EAS watcher did not observe the live EAS attestation log in time. The
-settlement was completed by calling the vault's permissionless `payout(...)`
-directly with the valid attestation UID after a successful `cast call`
-simulation.
+The original live coordinator opened the claim and requested the Chainlink
+fact, but its EAS watcher did not observe the live EAS attestation log in
+time. The settlement was completed by calling the vault's permissionless
+`payout(...)` directly with the valid attestation UID after a successful
+`cast call` simulation.
+
+The current coordinator now backfills recent EAS `Attested` logs when the
+watcher starts, then keeps the live subscription open. That makes the demo
+more tolerant of restart or RPC polling gaps while preserving the same
+on-chain validation path.
 
 This still proves the live Base Sepolia contract path:
 
@@ -187,6 +232,7 @@ cast call "$VAULT" "balanceOf(bytes32)(uint256)" "$REPO_ID" --rpc-url "$BASE_SEP
 cast call "$FACT" "requestIdOf(bytes32)(bytes32)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
 cast call "$FACT" "getFact(bytes32)(bool,bytes)" "$CLAIM" --rpc-url "$BASE_SEPOLIA_RPC_URL"
 cast call "$EAS" "getAttestation(bytes32)((bytes32,bytes32,uint64,uint64,uint64,bytes32,address,address,bool,bytes))" "$UID" --rpc-url "$BASE_SEPOLIA_RPC_URL"
+cast receipt 0x83168e5e3cc84d5bb819cfa59da64a2a685f3e91857b5f438807b86ac8eccd07 --rpc-url "$BASE_SEPOLIA_RPC_URL"
 cast call "$USDC" "balanceOf(address)(uint256)" "$RECIPIENT" --rpc-url "$BASE_SEPOLIA_RPC_URL"
 cast call "$USDC" "balanceOf(address)(uint256)" "$ATTESTER" --rpc-url "$BASE_SEPOLIA_RPC_URL"
 ```

--- a/packages/coordinator/src/adapters/eas-watcher.ts
+++ b/packages/coordinator/src/adapters/eas-watcher.ts
@@ -5,6 +5,17 @@ import { type Address, type Hex, type PublicClient, decodeAbiParameters } from "
 import type { AttestationInbox } from "../inbox.js";
 import type { ClaimState } from "../types.js";
 
+interface EasWatcherOptions {
+  backfillBlocks?: bigint;
+}
+
+interface EasAttestedLog {
+  args: {
+    uid?: Hex;
+    attester?: Address;
+  };
+}
+
 /// Watches the EAS contract for `Attested(...)` events under the vault's
 /// schema and forwards them into the AttestationInbox. The coordinator's
 /// pipeline awaits the inbox; once threshold attestations land for a
@@ -29,6 +40,7 @@ export class EasAttestationWatcher {
     /// the web verifier theater so the UI surfaces UIDs as they land.
     private readonly events?: EventSubscriber,
     private readonly logger?: { warn: (msg: string) => void },
+    private readonly options: EasWatcherOptions = {},
   ) {}
 
   start(): void {
@@ -39,13 +51,10 @@ export class EasAttestationWatcher {
       eventName: "Attested",
       args: { schema: this.schemaUID },
       onLogs: (logs) => {
-        for (const log of logs) {
-          this.handleLog(log).catch((e) => {
-            this.logger?.warn(`eas-watcher handleLog failed: ${(e as Error).message}`);
-          });
-        }
+        this.handleLogs(logs as EasAttestedLog[]);
       },
     });
+    void this.backfillRecentLogs();
   }
 
   stop(): void {
@@ -53,7 +62,36 @@ export class EasAttestationWatcher {
     this.unwatch = undefined;
   }
 
-  private async handleLog(log: { args: { uid?: Hex; attester?: Address } }): Promise<void> {
+  private async backfillRecentLogs(): Promise<void> {
+    const backfillBlocks = this.options.backfillBlocks ?? 500n;
+    if (backfillBlocks <= 0n) return;
+
+    try {
+      const head = await this.publicClient.getBlockNumber();
+      const fromBlock = head > backfillBlocks ? head - backfillBlocks : 0n;
+      const logs = await this.publicClient.getContractEvents({
+        address: this.easAddress,
+        abi: mockEASAbi,
+        eventName: "Attested",
+        args: { schema: this.schemaUID },
+        fromBlock,
+        toBlock: head,
+      });
+      this.handleLogs(logs as EasAttestedLog[]);
+    } catch (e) {
+      this.logger?.warn(`eas-watcher backfill failed: ${(e as Error).message}`);
+    }
+  }
+
+  private handleLogs(logs: EasAttestedLog[]): void {
+    for (const log of logs) {
+      this.handleLog(log).catch((e) => {
+        this.logger?.warn(`eas-watcher handleLog failed: ${(e as Error).message}`);
+      });
+    }
+  }
+
+  private async handleLog(log: EasAttestedLog): Promise<void> {
     const uid = log.args.uid;
     const attester = log.args.attester;
     if (!uid || !attester) return;

--- a/packages/coordinator/test/eas-watcher.test.ts
+++ b/packages/coordinator/test/eas-watcher.test.ts
@@ -56,10 +56,13 @@ function makeWatcher(args: {
   state?: ClaimState;
   logger?: { warn: (msg: string) => void };
   events?: { publish: (e: unknown) => void };
+  publicClient?: Partial<PublicClient>;
+  backfillBlocks?: bigint;
 }): EasAttestationWatcher {
   const publicClient = {
     readContract: vi.fn().mockResolvedValue(args.attestation),
     watchContractEvent: vi.fn(),
+    ...args.publicClient,
   } as unknown as PublicClient;
 
   return new EasAttestationWatcher(
@@ -70,7 +73,23 @@ function makeWatcher(args: {
     () => args.state,
     args.events as never,
     args.logger,
+    { backfillBlocks: args.backfillBlocks },
   );
+}
+
+function makeWatcherWithClient(args: {
+  inbox: AttestationInbox;
+  attestation: MockAttestation;
+  state?: ClaimState;
+  logger?: { warn: (msg: string) => void };
+  events?: { publish: (e: unknown) => void };
+  publicClient: Partial<PublicClient>;
+  backfillBlocks?: bigint;
+}): { watcher: EasAttestationWatcher; publicClient: Partial<PublicClient> } {
+  return {
+    watcher: makeWatcher(args),
+    publicClient: args.publicClient,
+  };
 }
 
 async function deliverLog(
@@ -87,6 +106,68 @@ async function deliverLog(
 }
 
 describe("EasAttestationWatcher.handleLog", () => {
+  it("backfills recent Attested logs on start so restart-time attestations still settle", async () => {
+    const inbox = new AttestationInbox();
+    const events = { publish: vi.fn() };
+    const uid = `0x${"cc".repeat(32)}` as Hex;
+    const state = makeState();
+    const publicClient = {
+      readContract: vi.fn().mockResolvedValue({
+        uid,
+        schema: SCHEMA,
+        revocationTime: 0n,
+        attester: ATTESTER,
+        data: encodeAbiParameters(
+          [{ type: "bytes32" }, { type: "bytes32" }, { type: "bool" }],
+          [CLAIM_ID, STATE_FACT_HASH, true],
+        ),
+      }),
+      watchContractEvent: vi.fn(),
+      getBlockNumber: vi.fn().mockResolvedValue(120n),
+      getContractEvents: vi.fn().mockResolvedValue([{ args: { uid, attester: ATTESTER } }]),
+    };
+
+    const waiterPromise = inbox.await({
+      claimId: CLAIM_ID,
+      factHash: STATE_FACT_HASH,
+      threshold: 1,
+      trustedAttesters: new Set([ATTESTER.toLowerCase()]),
+      timeoutMs: 1_000,
+    });
+    const { watcher } = makeWatcherWithClient({
+      inbox,
+      attestation: {
+        uid,
+        schema: SCHEMA,
+        revocationTime: 0n,
+        attester: ATTESTER,
+        data: "0x",
+      },
+      state,
+      events,
+      publicClient: publicClient as never,
+      backfillBlocks: 25n,
+    });
+
+    watcher.start();
+
+    await vi.waitFor(() => {
+      expect(publicClient.getContractEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: EAS_ADDR,
+          eventName: "Attested",
+          args: { schema: SCHEMA },
+          fromBlock: 95n,
+          toBlock: 120n,
+        }),
+      );
+    });
+    await expect(waiterPromise).resolves.toEqual([uid]);
+    expect(events.publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "attestation.observed", uid }),
+    );
+  });
+
   it("drops attestations whose decoded factHash does not match state.factHash", async () => {
     const inbox = new AttestationInbox();
     const warn = vi.fn();


### PR DESCRIPTION
## Summary
- add recent EAS Attested log backfill on coordinator watcher startup
- add a regression test proving restart-time attestations are routed into the inbox
- add root README demo instructions and live Base Sepolia EAS log proof to the docs

## Verification
- pnpm --filter @x502/coordinator exec vitest run test/eas-watcher.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:ts
- forge test --root contracts

## Demo notes
- local UI remains the smooth recording path at http://127.0.0.1:3000/?mode=demo
- live Base Sepolia proof is in docs/sepolia-demo.md with raw EAS receipt log and explorer links