### PR TITLE
refactor(web): polish the demo UI

### DIFF
--- a/demo/scripts/sepolia-replay.fixture.json
+++ b/demo/scripts/sepolia-replay.fixture.json
@@ -1,27 +1,44 @@
 {
-  "_comment": "Replace this fixture with a real recorded Base Sepolia run. Each entry is one bounty kind. After running the live Sepolia flow, capture the claimId, payout txHash, factHash, and verifier signatures from coordinator logs.",
+  "_comment": "Recorded Base Sepolia runs against the live EAS-flavor BountyVault. Each entry is one bounty kind. To add a new run, capture the claimId, payoutTx, factHash, and verifier signatures from the coordinator log + EAS attestation receipt.",
   "network": {
     "chainId": 84532,
     "label": "Base Sepolia",
     "explorer": "https://sepolia.basescan.org"
   },
-  "vault": "0x0000000000000000000000000000000000000000",
-  "factReceiver": "0x0000000000000000000000000000000000000000",
+  "vault": "0x951395a508ddF903e8F766960c93D94120F30877",
+  "factReceiver": "0x8e4f147B51F1013aFa72B9b84EAB67893890edE6",
   "runs": [
     {
       "kind": "report",
-      "repo": "skanislav/x502-sepolia-demo",
-      "externalId": "1",
-      "claimId": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "factHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "payoutTx": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "claimant": "0x0000000000000000000000000000000000000000",
-      "claimantAmountUsdc": "4.80",
+      "repo": "skanislav/x502",
+      "externalId": "13",
+      "claimId": "0x18e06d3da5572f3a21167c4983ffd77b7f0e23a96e05c8e17c283ff00b861f06",
+      "factHash": "0xfdb18441e612a66fa82de11c60b1bcf1aa493f43c6d86c28c2f86224d3467152",
+      "payoutTx": "0xa58956704407c0bd33dda379229e4e1c96c46489703a024c120792ca9ddac433",
+      "claimant": "0x3EB5c6E32Db62E2e107f6572D23dC798cad7aAEa",
+      "claimantAmountUsdc": "0.049",
       "verifierSignatures": [
-        { "agentId": "101", "signature": "0x" },
-        { "agentId": "102", "signature": "0x" }
-      ],
-      "_status": "placeholder"
+        {
+          "agentId": "5260",
+          "signature": "0xdd2f701bcc3330d3449ea8e3506f322f1d7f5183ee5790c4b47222cc90d19a3c"
+        }
+      ]
+    },
+    {
+      "kind": "triage",
+      "repo": "skanislav/x502",
+      "externalId": "11",
+      "claimId": "0x91210205709cbf16a70beac202fe50db80a1a7b5e80137b5ec401d2e6c26d976",
+      "factHash": "0x3f9fec8821542c223479bc8afa58b1cd9b897533967e3edd6d5fec7d96c7ddef",
+      "payoutTx": "0x79235844c7dd84fc45036ab7e46aa978407dd368bb4f4b61bf62b8f6668bd613",
+      "claimant": "0x3EB5c6E32Db62E2e107f6572D23dC798cad7aAEa",
+      "claimantAmountUsdc": "0.019",
+      "verifierSignatures": [
+        {
+          "agentId": "5260",
+          "signature": "0xfa94ed9ddde4dda3d97c26089982177d9b178da518503e09b031d3be27bda686"
+        }
+      ]
     }
   ]
 }

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -8,6 +8,133 @@
 
 html,
 body {
-  background: theme(colors.ink);
-  color: theme(colors.paper);
+  background: theme(colors.ink.DEFAULT);
+  color: theme(colors.text.strong);
+}
+
+/* The page sits on top of a deep ink base; we paint a soft radial accent
+   glow at top-right plus a faint dot grid at the very back, then fade
+   them so they never compete with content. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(1100px 540px at 88% -8%, rgba(91, 141, 255, 0.18), transparent 60%),
+    radial-gradient(800px 600px at -6% 110%, rgba(91, 141, 255, 0.07), transparent 55%);
+  z-index: 0;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 24px 24px;
+  mask-image: radial-gradient(circle at 50% 30%, black 0%, transparent 70%);
+  opacity: 0.55;
+  z-index: 0;
+}
+
+main,
+header,
+footer,
+section,
+article {
+  position: relative;
+  z-index: 1;
+}
+
+/* Native scrollbar styling — matte, in-palette. */
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+/* Selection */
+::selection {
+  background: rgba(91, 141, 255, 0.32);
+  color: white;
+}
+
+@layer components {
+  .x502-input {
+    @apply w-full bg-ink-700/80 border border-line rounded-lg px-3.5 py-2.5 text-sm
+      text-text-strong placeholder:text-text-faint
+      transition-colors duration-150
+      focus:outline-none focus:border-accent focus:shadow-ring;
+  }
+
+  .x502-input-mono {
+    @apply x502-input font-mono text-[12.5px] tracking-tight;
+  }
+
+  .x502-card {
+    @apply rounded-2xl border border-line bg-ink-800/70 backdrop-blur-sm
+      shadow-card;
+  }
+
+  .x502-card-tight {
+    @apply x502-card p-5;
+  }
+
+  .x502-eyebrow {
+    @apply text-2xs uppercase tracking-[0.18em] font-medium text-text-muted;
+  }
+
+  .x502-pill {
+    @apply inline-flex items-center gap-1.5 rounded-full border border-line
+      bg-ink-700/80 px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-text-muted;
+  }
+
+  .x502-pill-accent {
+    @apply x502-pill border-accent/40 bg-accent/10 text-accent;
+  }
+
+  .x502-pill-success {
+    @apply x502-pill border-success/40 bg-success/10 text-success;
+  }
+
+  .x502-pill-danger {
+    @apply x502-pill border-danger/40 bg-danger/10 text-danger;
+  }
+
+  .x502-link {
+    @apply text-accent decoration-accent/40 underline-offset-4 hover:underline transition-colors;
+  }
+
+  .x502-button {
+    @apply inline-flex items-center justify-center gap-2 rounded-xl
+      bg-accent px-5 py-3 text-sm font-semibold text-white
+      shadow-glow transition-all duration-150
+      hover:bg-accent-soft hover:shadow-[0_0_0_1px_rgba(128,168,255,0.6),0_0_36px_-6px_rgba(128,168,255,0.55)]
+      focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-ring
+      disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none;
+  }
+
+  .x502-button-secondary {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg
+      border border-line bg-ink-700/80 px-3 py-2 text-xs font-medium
+      text-text-strong transition-colors duration-150
+      hover:border-line-strong hover:bg-ink-600
+      focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-ring
+      disabled:cursor-not-allowed disabled:opacity-40;
+  }
+
+  .x502-mono {
+    @apply font-mono tracking-tight text-[12.5px];
+  }
 }

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,3 +1,5 @@
+import { GeistMono } from "geist/font/mono";
+import { GeistSans } from "geist/font/sans";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -9,8 +11,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="font-mono antialiased min-h-screen">{children}</body>
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+      <body className="font-sans antialiased min-h-screen bg-ink text-text">{children}</body>
     </html>
   );
 }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -545,12 +545,12 @@ function ClaimForm({
         )}
       </button>
 
-      {pipeline.status !== "idle" && <PipelineStatus state={pipeline} />}
+      {pipeline.status !== "idle" && <PipelineStatus state={pipeline} threshold={verifierCount} />}
     </section>
   );
 }
 
-function PipelineStatus({ state }: { state: PipelineState }) {
+function PipelineStatus({ state, threshold }: { state: PipelineState; threshold: number }) {
   if (state.status === "paid" && state.txHash) {
     return (
       <div className="rounded-xl border border-success/40 bg-success/10 p-4 space-y-2 animate-fade-up">
@@ -585,11 +585,15 @@ function PipelineStatus({ state }: { state: PipelineState }) {
     );
   }
 
-  // Verifying — render the four-stage pipeline as a horizontal track.
+  // Verifying — render the four-stage pipeline as a horizontal track. The
+  // verifier-sigs denominator is the configured M-of-N threshold (defaults
+  // to 1 for the Base Sepolia single-attester demo) so the stage flips to
+  // "done" the moment the coordinator has enough attestations to settle.
+  const sigs = state.sigs ?? 0;
   const stages: Array<{ label: string; done: boolean }> = [
     { label: "Anti-spam fee", done: state.status !== "idle" },
     { label: "Chainlink fact", done: state.factReady === true },
-    { label: `Verifier sigs (${state.sigs ?? 0}/2)`, done: (state.sigs ?? 0) >= 2 },
+    { label: `Verifier sigs (${sigs}/${threshold})`, done: sigs >= threshold },
     { label: "Vault payout", done: state.status === "paid" },
   ];
 

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
+import type { KindName } from "@x502/shared";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { type Address, type Hex, isAddress } from "viem";
+
 import { DemoStepper, type StepKey, stepFromPipeline } from "@/components/DemoStepper";
 import { SepoliaReplay } from "@/components/SepoliaReplay";
 import { VerifierTheater } from "@/components/VerifierTheater";
 import { type PipelineState, mapPoll, previewCommitment } from "@/lib/claim-ui";
 import { CoordinatorClient } from "@/lib/coordinator";
 import { basescanTx, formatUsdc, shortHash } from "@/lib/format";
-import type { KindName } from "@x502/shared";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { type Address, type Hex, isAddress } from "viem";
 
 const DEFAULT_COORDINATOR = process.env.NEXT_PUBLIC_COORDINATOR_URL ?? "http://localhost:8787";
 
@@ -20,9 +21,6 @@ interface DemoConfig {
   contracts?: { eas?: string };
 }
 
-/// Attest.org explorer base URL per chain. Returns undefined when we don't
-/// recognize the chain (the verifier theater then renders the UID as
-/// plain text instead of a link).
 function easExplorer(chainId: number | undefined): string | undefined {
   if (chainId === 8453) return "https://base.easscan.org/attestation/view";
   if (chainId === 84532) return "https://base-sepolia.easscan.org/attestation/view";
@@ -69,7 +67,6 @@ export default function Page() {
   const [pipeline, setPipeline] = useState<PipelineState>({ status: "idle" });
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Demo-mode state — populated by /api/demo-config when ?mode=demo is set.
   const [demoMode, setDemoMode] = useState(false);
   const [demoCfg, setDemoCfg] = useState<DemoConfig | undefined>();
   useEffect(() => {
@@ -146,168 +143,15 @@ export default function Page() {
     }, 1500);
   }
 
-  const claimForm = (
-    <>
-      <section className="space-y-4">
-        <h2 className="text-xs uppercase tracking-widest text-muted">Coordinator</h2>
-        <input
-          type="text"
-          value={coordinatorUrl}
-          onChange={(e) => setCoordinatorUrl(e.target.value)}
-          className="w-full bg-paper/5 border border-paper/10 rounded px-3 py-2 text-sm focus:outline-none focus:border-accent"
-          placeholder="http://localhost:8787"
-        />
-      </section>
-
-      <section className="space-y-4">
-        <h2 className="text-xs uppercase tracking-widest text-muted">File a claim</h2>
-
-        <Field label="Repo (owner/name)">
-          <input value={repoSlug} onChange={(e) => setRepoSlug(e.target.value)} className="input" />
-        </Field>
-
-        <Field label="Issue or PR number">
-          <input
-            value={externalId}
-            onChange={(e) => setExternalId(e.target.value)}
-            inputMode="numeric"
-            className="input"
-          />
-        </Field>
-
-        <Field label="Bounty kind">
-          <div className="grid grid-cols-2 gap-2">
-            {(Object.keys(KIND_META) as KindName[]).map((k) => {
-              const m = KIND_META[k];
-              const selected = k === kind;
-              return (
-                <button
-                  type="button"
-                  key={k}
-                  onClick={() => setKind(k)}
-                  className={[
-                    "text-left rounded border px-3 py-2 transition",
-                    selected
-                      ? "border-accent bg-accent/10"
-                      : "border-paper/10 hover:border-paper/30",
-                  ].join(" ")}
-                >
-                  <div className="flex items-baseline justify-between">
-                    <span className="font-semibold">{m.label}</span>
-                    <span className="text-xs text-muted">{formatUsdc(m.price)}</span>
-                  </div>
-                  <div className="text-xs text-muted leading-5">{m.description}</div>
-                </button>
-              );
-            })}
-          </div>
-        </Field>
-
-        <Field label="Recipient (your wallet)">
-          <input
-            value={recipient}
-            onChange={(e) => setRecipient(e.target.value)}
-            placeholder="0x…"
-            className="input"
-          />
-        </Field>
-
-        <details className="text-sm" open={demoMode}>
-          <summary className="cursor-pointer text-muted">
-            Identity binding (commitment reveal)
-          </summary>
-          <div className="space-y-3 pt-3">
-            <Field label="Agent ID (ERC-8004 token id)">
-              <input
-                value={agentIdReveal}
-                onChange={(e) => setAgentIdReveal(e.target.value)}
-                inputMode="numeric"
-                className="input"
-              />
-            </Field>
-            <Field label="Salt (bytes32)">
-              <input
-                value={saltReveal}
-                onChange={(e) => setSaltReveal(e.target.value)}
-                className="input font-mono text-xs"
-              />
-            </Field>
-            <div className="text-xs text-muted">
-              Must match the
-              <code className="mx-1 px-1 bg-paper/5 rounded">
-                {"<!-- x502-commitment:0x... -->"}
-              </code>
-              line in the GH issue/PR body.
-            </div>
-            {commitmentPreview && (
-              <div className="text-xs font-mono break-all bg-paper/5 rounded p-2">
-                {commitmentPreview}
-              </div>
-            )}
-          </div>
-        </details>
-
-        <div className="rounded border border-paper/10 p-4 space-y-1 text-sm">
-          <div className="flex justify-between">
-            <span className="text-muted">Bounty</span>
-            <span>{formatUsdc(meta.price)}</span>
-          </div>
-          <div className="flex justify-between text-muted text-xs">
-            <span>
-              − verifier outcome fees ({VERIFIER_COUNT} × {formatUsdc(OUTCOME_FEE_PER_VERIFIER)})
-            </span>
-            <span>−{formatUsdc(OUTCOME_FEE_PER_VERIFIER * BigInt(VERIFIER_COUNT))}</span>
-          </div>
-          <hr className="border-paper/10 my-1" />
-          <div className="flex justify-between font-semibold">
-            <span>You receive</span>
-            <span className="text-accent">{formatUsdc(claimantAmount)}</span>
-          </div>
-        </div>
-
-        <button
-          type="button"
-          onClick={submit}
-          disabled={pipeline.status === "verifying"}
-          className="w-full bg-accent text-paper rounded py-3 font-semibold disabled:opacity-50"
-        >
-          {pipeline.status === "verifying" ? "Verifying…" : "Submit claim"}
-        </button>
-      </section>
-
-      {pipeline.status !== "idle" && (
-        <section className="space-y-3">
-          <h2 className="text-xs uppercase tracking-widest text-muted">Status</h2>
-          <PipelineStatus state={pipeline} />
-        </section>
-      )}
-    </>
-  );
-
   return (
-    <main className={`mx-auto p-8 space-y-10 ${demoMode ? "max-w-7xl" : "max-w-3xl"}`}>
-      <header className="space-y-2">
-        <h1 className="text-3xl font-bold tracking-tight">
-          x502
-          <span className="text-muted text-base ml-3">
-            services pay agents for verifiable GitHub outcomes
-          </span>
-        </h1>
-        <p className="text-sm text-muted leading-6">
-          File a claim against a vault-funded repo. The coordinator routes the claim through
-          Chainlink Functions (objective fact) and N-of-M verifier agents (subjective judgment),
-          then settles to your wallet on Base.
-        </p>
-        {demoMode && (
-          <div className="text-xs text-accent">
-            demo mode {demoCfg ? `· coordinator ${demoCfg.coordinator.endpoint}` : ""}
-          </div>
-        )}
-      </header>
+    <main
+      className={`mx-auto px-6 sm:px-8 lg:px-10 pt-10 pb-20 space-y-12 ${demoMode ? "max-w-7xl" : "max-w-4xl"}`}
+    >
+      <Hero demoMode={demoMode} demoCfg={demoCfg} />
 
       {demoMode ? (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="space-y-6">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8">
+          <div className="lg:col-span-5 space-y-6 animate-fade-up">
             <DemoStepper
               current={stepperStep}
               commitmentForm={{
@@ -320,8 +164,30 @@ export default function Page() {
               }}
             />
           </div>
-          <div className="space-y-6">{claimForm}</div>
-          <div className="space-y-6">
+          <div className="lg:col-span-7 space-y-6 animate-fade-up [animation-delay:80ms]">
+            <ClaimForm
+              coordinatorUrl={coordinatorUrl}
+              setCoordinatorUrl={setCoordinatorUrl}
+              repoSlug={repoSlug}
+              setRepoSlug={setRepoSlug}
+              externalId={externalId}
+              setExternalId={setExternalId}
+              kind={kind}
+              setKind={setKind}
+              recipient={recipient}
+              setRecipient={setRecipient}
+              agentIdReveal={agentIdReveal}
+              setAgentIdReveal={setAgentIdReveal}
+              saltReveal={saltReveal}
+              setSaltReveal={setSaltReveal}
+              commitmentPreview={commitmentPreview}
+              onSubmit={submit}
+              pipeline={pipeline}
+              meta={meta}
+              claimantAmount={claimantAmount}
+              demoMode={demoMode}
+            />
+
             <VerifierTheater
               coordinatorUrl={coordinatorUrl}
               claimId={pipeline.claimId}
@@ -337,40 +203,427 @@ export default function Page() {
               }
               easExplorerBase={easExplorer(demoCfg?.chainId)}
             />
+
             <SepoliaReplay />
           </div>
         </div>
       ) : (
-        claimForm
+        <div className="space-y-8 animate-fade-up">
+          <ClaimForm
+            coordinatorUrl={coordinatorUrl}
+            setCoordinatorUrl={setCoordinatorUrl}
+            repoSlug={repoSlug}
+            setRepoSlug={setRepoSlug}
+            externalId={externalId}
+            setExternalId={setExternalId}
+            kind={kind}
+            setKind={setKind}
+            recipient={recipient}
+            setRecipient={setRecipient}
+            agentIdReveal={agentIdReveal}
+            setAgentIdReveal={setAgentIdReveal}
+            saltReveal={saltReveal}
+            setSaltReveal={setSaltReveal}
+            commitmentPreview={commitmentPreview}
+            onSubmit={submit}
+            pipeline={pipeline}
+            meta={meta}
+            claimantAmount={claimantAmount}
+            demoMode={demoMode}
+          />
+        </div>
       )}
 
-      <footer className="text-xs text-muted pt-4 border-t border-paper/10 space-y-1">
-        <div>
-          x402 = agents pay services. x502 = services pay agents. This is the inverse: the vault
-          pays out for verified outcomes, and verifier compute is x402-paid by the coordinator from
-          the anti-spam-fee budget.
-        </div>
-        <div>
-          Sources: Base Sepolia (chainId 84532) + ERC-8004 IdentityRegistry 0x8004A8… + Chainlink
-          Functions Router 0xf9B8fc…
-        </div>
-      </footer>
-
-      <style jsx>{`
-        .input {
-          width: 100%;
-          background: rgba(250, 250, 246, 0.05);
-          border: 1px solid rgba(250, 250, 246, 0.1);
-          border-radius: 0.25rem;
-          padding: 0.5rem 0.75rem;
-          font-size: 0.875rem;
-        }
-        .input:focus {
-          outline: none;
-          border-color: #0052ff;
-        }
-      `}</style>
+      <Footer />
     </main>
+  );
+}
+
+function Hero({
+  demoMode,
+  demoCfg,
+}: {
+  demoMode: boolean;
+  demoCfg: DemoConfig | undefined;
+}) {
+  return (
+    <header className="space-y-6 animate-fade-up">
+      <div className="flex flex-wrap items-center gap-3">
+        {demoMode ? (
+          <span className="x502-pill-success">
+            <span className="relative inline-flex h-1.5 w-1.5">
+              <span className="absolute inset-0 rounded-full bg-success animate-ping opacity-60" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-success" />
+            </span>
+            Live · Base Sepolia
+          </span>
+        ) : (
+          <span className="x502-pill-accent">protocol preview</span>
+        )}
+        <span className="x502-pill">chain 84532</span>
+        <span className="x502-pill">M-of-N · EAS</span>
+      </div>
+      <div className="space-y-4 max-w-3xl">
+        <h1 className="font-mono text-5xl sm:text-6xl font-medium tracking-tightest text-text-strong">
+          x502
+          <span className="ml-3 inline-block h-2 w-2 translate-y-[-0.45em] rounded-full bg-accent shadow-glow" />
+        </h1>
+        <p className="font-sans text-xl sm:text-2xl text-text-strong leading-snug tracking-tight">
+          Services pay agents for <span className="text-accent">verifiable GitHub outcomes.</span>
+        </p>
+        <p className="text-text-muted text-base leading-relaxed">
+          A repo owner funds a USDC vault. A claimant submits an issue or PR. Chainlink Functions
+          stamps the GitHub fact on-chain. Verifier agents publish EAS attestations. The vault
+          settles on Base — no custodian, no oracle of last resort.
+        </p>
+      </div>
+      {demoMode && demoCfg && (
+        <div className="x502-card-tight max-w-3xl flex flex-wrap gap-x-8 gap-y-3 text-sm">
+          <Kv label="coordinator" value={demoCfg.coordinator.endpoint} mono />
+          <Kv label="repo" value={demoCfg.repo.slug} mono />
+          <Kv
+            label="verifiers"
+            value={`${demoCfg.verifiers.length} trusted (agent ${demoCfg.verifiers[0]?.agentId ?? "?"})`}
+          />
+        </div>
+      )}
+    </header>
+  );
+}
+
+function Kv({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="x502-eyebrow">{label}</div>
+      <div className={mono ? "font-mono text-[13px] text-text-strong" : "text-text-strong"}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ClaimForm({
+  coordinatorUrl,
+  setCoordinatorUrl,
+  repoSlug,
+  setRepoSlug,
+  externalId,
+  setExternalId,
+  kind,
+  setKind,
+  recipient,
+  setRecipient,
+  agentIdReveal,
+  setAgentIdReveal,
+  saltReveal,
+  setSaltReveal,
+  commitmentPreview,
+  onSubmit,
+  pipeline,
+  meta,
+  claimantAmount,
+  demoMode,
+}: {
+  coordinatorUrl: string;
+  setCoordinatorUrl: (v: string) => void;
+  repoSlug: string;
+  setRepoSlug: (v: string) => void;
+  externalId: string;
+  setExternalId: (v: string) => void;
+  kind: KindName;
+  setKind: (k: KindName) => void;
+  recipient: string;
+  setRecipient: (v: string) => void;
+  agentIdReveal: string;
+  setAgentIdReveal: (v: string) => void;
+  saltReveal: string;
+  setSaltReveal: (v: string) => void;
+  commitmentPreview: `0x${string}` | undefined;
+  onSubmit: () => Promise<void>;
+  pipeline: PipelineState;
+  meta: { label: string; price: bigint; description: string };
+  claimantAmount: bigint;
+  demoMode: boolean;
+}) {
+  const [bindingOpen, setBindingOpen] = useState(demoMode);
+  return (
+    <section className="x502-card p-6 sm:p-7 space-y-6">
+      <div className="flex items-end justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="x502-eyebrow">File a claim</h2>
+          <p className="text-text-muted text-sm">
+            POST to the coordinator. The pipeline runs from here.
+          </p>
+        </div>
+        <PipelinePill state={pipeline} />
+      </div>
+
+      <Field label="Coordinator">
+        <input
+          type="text"
+          value={coordinatorUrl}
+          onChange={(e) => setCoordinatorUrl(e.target.value)}
+          className="x502-input"
+          placeholder="http://localhost:8787"
+        />
+      </Field>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Field label="Repo (owner / name)">
+          <input
+            value={repoSlug}
+            onChange={(e) => setRepoSlug(e.target.value)}
+            className="x502-input"
+            placeholder="acme/widgets"
+          />
+        </Field>
+        <Field label="Issue or PR number">
+          <input
+            value={externalId}
+            onChange={(e) => setExternalId(e.target.value)}
+            inputMode="numeric"
+            className="x502-input"
+            placeholder="123"
+          />
+        </Field>
+      </div>
+
+      <div className="space-y-2.5">
+        <span className="x502-eyebrow">Bounty kind</span>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+          {(Object.keys(KIND_META) as KindName[]).map((k) => {
+            const m = KIND_META[k];
+            const selected = k === kind;
+            return (
+              <button
+                type="button"
+                key={k}
+                onClick={() => setKind(k)}
+                className={[
+                  "group text-left rounded-xl border p-3.5 transition-all duration-150",
+                  selected
+                    ? "border-accent bg-accent/10 shadow-glow"
+                    : "border-line bg-ink-700/60 hover:border-line-strong hover:bg-ink-600/60",
+                ].join(" ")}
+              >
+                <div className="flex items-baseline justify-between gap-3">
+                  <span
+                    className={[
+                      "font-mono text-base",
+                      selected ? "text-text-strong" : "text-text-strong",
+                    ].join(" ")}
+                  >
+                    {m.label}
+                  </span>
+                  <span
+                    className={[
+                      "font-mono text-sm tabular-nums",
+                      selected ? "text-accent" : "text-text-muted",
+                    ].join(" ")}
+                  >
+                    {formatUsdc(m.price)}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs leading-snug text-text-muted">{m.description}</p>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <Field label="Recipient (your wallet)">
+        <input
+          value={recipient}
+          onChange={(e) => setRecipient(e.target.value)}
+          placeholder="0x…"
+          className="x502-input-mono"
+          spellCheck={false}
+        />
+      </Field>
+
+      <div className="x502-card-tight border-line/80 bg-ink-700/50 space-y-3">
+        <button
+          type="button"
+          onClick={() => setBindingOpen((v) => !v)}
+          aria-expanded={bindingOpen}
+          className="w-full flex items-center justify-between gap-2 text-left"
+        >
+          <span className="space-y-0.5">
+            <span className="block x502-eyebrow">Identity binding · commitment reveal</span>
+            <span className="block text-xs text-text-muted">
+              Pre-image of the <code className="font-mono">x502-commitment</code> marker on GitHub.
+            </span>
+          </span>
+          <Chevron open={bindingOpen} />
+        </button>
+        {bindingOpen && (
+          <div className="space-y-3 pt-2 animate-fade-up">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Field label="Agent ID (ERC-8004 token id)">
+                <input
+                  value={agentIdReveal}
+                  onChange={(e) => setAgentIdReveal(e.target.value)}
+                  inputMode="numeric"
+                  className="x502-input"
+                />
+              </Field>
+              <Field label="Salt (bytes32)">
+                <input
+                  value={saltReveal}
+                  onChange={(e) => setSaltReveal(e.target.value)}
+                  className="x502-input-mono"
+                  spellCheck={false}
+                />
+              </Field>
+            </div>
+            {commitmentPreview && (
+              <div className="rounded-lg border border-line bg-ink-800/80 p-3 space-y-1.5">
+                <div className="x502-eyebrow">commitment</div>
+                <code className="block font-mono text-[12.5px] leading-relaxed text-text-strong break-all">
+                  {commitmentPreview}
+                </code>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-line bg-ink-700/40 p-4 space-y-1.5 text-sm">
+        <div className="flex justify-between">
+          <span className="text-text-muted">Bounty</span>
+          <span className="font-mono tabular-nums text-text-strong">{formatUsdc(meta.price)}</span>
+        </div>
+        <div className="flex justify-between text-text-muted text-xs">
+          <span>
+            verifier outcome fees ({VERIFIER_COUNT} × {formatUsdc(OUTCOME_FEE_PER_VERIFIER)})
+          </span>
+          <span className="font-mono tabular-nums">
+            −{formatUsdc(OUTCOME_FEE_PER_VERIFIER * BigInt(VERIFIER_COUNT))}
+          </span>
+        </div>
+        <div className="border-t border-line my-1.5" />
+        <div className="flex justify-between font-medium">
+          <span>You receive</span>
+          <span className="font-mono tabular-nums text-accent">{formatUsdc(claimantAmount)}</span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onSubmit}
+        disabled={pipeline.status === "verifying"}
+        className="x502-button w-full"
+      >
+        {pipeline.status === "verifying" ? (
+          <>
+            <Spinner /> Verifying…
+          </>
+        ) : (
+          <>
+            Submit claim
+            <span aria-hidden className="text-white/60">
+              →
+            </span>
+          </>
+        )}
+      </button>
+
+      {pipeline.status !== "idle" && <PipelineStatus state={pipeline} />}
+    </section>
+  );
+}
+
+function PipelineStatus({ state }: { state: PipelineState }) {
+  if (state.status === "paid" && state.txHash) {
+    return (
+      <div className="rounded-xl border border-success/40 bg-success/10 p-4 space-y-2 animate-fade-up">
+        <div className="flex justify-between items-baseline">
+          <span className="font-medium text-success flex items-center gap-2">
+            <CheckIcon /> Paid
+          </span>
+          {state.claimId && (
+            <span className="x502-mono text-text-muted">claim {shortHash(state.claimId)}</span>
+          )}
+        </div>
+        <a
+          href={basescanTx(state.txHash)}
+          target="_blank"
+          rel="noreferrer"
+          className="block x502-mono text-success break-all hover:underline"
+        >
+          {state.txHash}
+        </a>
+      </div>
+    );
+  }
+
+  if (state.status === "failed") {
+    return (
+      <div className="rounded-xl border border-danger/40 bg-danger/10 p-4 text-sm space-y-1 animate-fade-up">
+        <div className="font-medium text-danger flex items-center gap-2">
+          <XIcon /> Failed
+        </div>
+        <div className="text-xs text-text-muted whitespace-pre-wrap break-words">{state.error}</div>
+      </div>
+    );
+  }
+
+  // Verifying — render the four-stage pipeline as a horizontal track.
+  const stages: Array<{ label: string; done: boolean }> = [
+    { label: "Anti-spam fee", done: state.status !== "idle" },
+    { label: "Chainlink fact", done: state.factReady === true },
+    { label: `Verifier sigs (${state.sigs ?? 0}/2)`, done: (state.sigs ?? 0) >= 2 },
+    { label: "Vault payout", done: state.status === "paid" },
+  ];
+
+  return (
+    <div className="rounded-xl border border-line bg-ink-700/40 p-4 space-y-3 animate-fade-up">
+      <div className="x502-eyebrow">Pipeline</div>
+      <ol className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {stages.map((s, i) => (
+          <li
+            key={s.label}
+            className={[
+              "flex items-center gap-2 rounded-lg px-3 py-2 text-xs transition-colors",
+              s.done
+                ? "border border-accent/40 bg-accent/10 text-text-strong"
+                : "border border-line bg-ink-800/60 text-text-muted",
+            ].join(" ")}
+          >
+            <span
+              className={[
+                "h-2 w-2 rounded-full shrink-0",
+                s.done
+                  ? "bg-accent"
+                  : i === stages.findIndex((x) => !x.done)
+                    ? "bg-accent/70 animate-pulse-ring"
+                    : "bg-text-faint",
+              ].join(" ")}
+            />
+            <span>{s.label}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function PipelinePill({ state }: { state: PipelineState }) {
+  if (state.status === "idle") return <span className="x502-pill">idle</span>;
+  if (state.status === "paid") return <span className="x502-pill-success">paid</span>;
+  if (state.status === "failed") return <span className="x502-pill-danger">failed</span>;
+  return (
+    <span className="x502-pill-accent">
+      <Spinner small /> verifying
+    </span>
   );
 }
 
@@ -382,62 +635,106 @@ function Field({
   children: React.ReactNode;
 }) {
   return (
-    // biome-ignore lint/a11y/noLabelWithoutControl: child inputs are nested inside this label.
-    <label className="block space-y-1">
-      <span className="text-xs text-muted">{label}</span>
+    // biome-ignore lint/a11y/noLabelWithoutControl: child input is rendered inside this label.
+    <label className="block space-y-1.5">
+      <span className="x502-eyebrow">{label}</span>
       {children}
     </label>
   );
 }
 
-function PipelineStatus({ state }: { state: PipelineState }) {
-  if (state.status === "paid" && state.txHash) {
-    return (
-      <div className="rounded border border-accent/40 bg-accent/5 p-4 space-y-2">
-        <div className="flex justify-between items-baseline">
-          <span className="font-semibold text-accent">Paid</span>
-          <span className="text-xs text-muted">{shortHash(state.claimId!)}</span>
-        </div>
-        <a
-          href={basescanTx(state.txHash)}
-          target="_blank"
-          rel="noreferrer"
-          className="text-xs text-accent underline break-all"
-        >
-          {state.txHash}
-        </a>
-      </div>
-    );
-  }
-
-  if (state.status === "failed") {
-    return (
-      <div className="rounded border border-red-500/40 bg-red-500/5 p-4 text-sm space-y-1">
-        <div className="font-semibold text-red-400">Failed</div>
-        <div className="text-xs text-muted">{state.error}</div>
-      </div>
-    );
-  }
-
+function Chevron({ open }: { open: boolean }) {
   return (
-    <div className="rounded border border-paper/10 p-4 space-y-2 text-sm">
-      <Step label="Anti-spam fee paid" done={state.status !== "idle"} />
-      <Step label="Chainlink Functions fact delivered" done={state.factReady === true} />
-      <Step label={`Verifier signatures (${state.sigs ?? 0} / 2)`} done={(state.sigs ?? 0) >= 2} />
-      <Step label="Vault payout tx" done={state.status === "paid"} />
-    </div>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`transition-transform duration-150 text-text-muted ${open ? "rotate-180" : ""}`}
+      role="img"
+      aria-label={open ? "collapse" : "expand"}
+    >
+      <title>{open ? "collapse" : "expand"}</title>
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
   );
 }
 
-function Step({ label, done }: { label: string; done: boolean }) {
+function CheckIcon() {
   return (
-    <div className="flex items-center gap-2">
-      <span
-        className={["h-3 w-3 rounded-full", done ? "bg-accent" : "bg-paper/20 animate-pulse"].join(
-          " ",
-        )}
-      />
-      <span className={done ? "text-paper" : "text-muted"}>{label}</span>
-    </div>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="checkmark"
+    >
+      <title>checkmark</title>
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="error"
+    >
+      <title>error</title>
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+function Spinner({ small = false }: { small?: boolean }) {
+  const size = small ? "h-3 w-3" : "h-4 w-4";
+  return (
+    <svg
+      className={`${size} animate-spin`}
+      viewBox="0 0 24 24"
+      fill="none"
+      role="img"
+      aria-label="loading"
+    >
+      <title>loading</title>
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeOpacity="0.25" strokeWidth="3" />
+      <path d="M21 12a9 9 0 0 0-9-9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function Footer() {
+  return (
+    <footer className="border-t border-line pt-6 space-y-2 text-text-muted text-sm">
+      <p>
+        x402 = agents pay services. <span className="text-text-strong">x502</span> = services pay
+        agents. The vault settles for verified outcomes; verifier compute is x402-paid by the
+        coordinator from the anti-spam-fee budget.
+      </p>
+      <p className="text-xs">
+        Sources: Base Sepolia (chainId 84532) · ERC-8004 IdentityRegistry{" "}
+        <code className="x502-mono text-text-strong">0x8004A8…</code> · Chainlink Functions Router{" "}
+        <code className="x502-mono text-text-strong">0xf9B8fc…</code>.
+      </p>
+    </footer>
   );
 }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -51,7 +51,11 @@ const KIND_META: Record<KindName, { label: string; price: bigint; description: s
 };
 
 const OUTCOME_FEE_PER_VERIFIER = 1_000n;
-const VERIFIER_COUNT = 2;
+/// Fallback verifier count for non-demo mode where we have no coordinator
+/// config to read from. The Base Sepolia demo configures one trusted
+/// attester (agent 5260, threshold 1); demo mode reads the actual count
+/// from /api/demo-config so the "you receive" amount stays accurate.
+const DEFAULT_VERIFIER_COUNT = 1;
 
 export default function Page() {
   const [coordinatorUrl, setCoordinatorUrl] = useState(DEFAULT_COORDINATOR);
@@ -86,7 +90,8 @@ export default function Page() {
   }, []);
 
   const meta = KIND_META[kind];
-  const claimantAmount = meta.price - OUTCOME_FEE_PER_VERIFIER * BigInt(VERIFIER_COUNT);
+  const verifierCount = demoCfg?.verifiers.length ?? DEFAULT_VERIFIER_COUNT;
+  const claimantAmount = meta.price - OUTCOME_FEE_PER_VERIFIER * BigInt(verifierCount);
   const stepperStep: StepKey = demoMode ? stepFromPipeline(pipeline) : "intro";
 
   const commitmentPreview = useMemo(
@@ -185,6 +190,7 @@ export default function Page() {
               pipeline={pipeline}
               meta={meta}
               claimantAmount={claimantAmount}
+              verifierCount={verifierCount}
               demoMode={demoMode}
             />
 
@@ -229,6 +235,7 @@ export default function Page() {
             pipeline={pipeline}
             meta={meta}
             claimantAmount={claimantAmount}
+            verifierCount={verifierCount}
             demoMode={demoMode}
           />
         </div>
@@ -330,6 +337,7 @@ function ClaimForm({
   pipeline,
   meta,
   claimantAmount,
+  verifierCount,
   demoMode,
 }: {
   coordinatorUrl: string;
@@ -351,6 +359,7 @@ function ClaimForm({
   pipeline: PipelineState;
   meta: { label: string; price: bigint; description: string };
   claimantAmount: bigint;
+  verifierCount: number;
   demoMode: boolean;
 }) {
   const [bindingOpen, setBindingOpen] = useState(demoMode);
@@ -503,10 +512,10 @@ function ClaimForm({
         </div>
         <div className="flex justify-between text-text-muted text-xs">
           <span>
-            verifier outcome fees ({VERIFIER_COUNT} × {formatUsdc(OUTCOME_FEE_PER_VERIFIER)})
+            verifier outcome fees ({verifierCount} × {formatUsdc(OUTCOME_FEE_PER_VERIFIER)})
           </span>
           <span className="font-mono tabular-nums">
-            −{formatUsdc(OUTCOME_FEE_PER_VERIFIER * BigInt(VERIFIER_COUNT))}
+            −{formatUsdc(OUTCOME_FEE_PER_VERIFIER * BigInt(verifierCount))}
           </span>
         </div>
         <div className="border-t border-line my-1.5" />

--- a/packages/web/components/DemoStepper.tsx
+++ b/packages/web/components/DemoStepper.tsx
@@ -12,46 +12,61 @@ export type StepKey =
   | "payout"
   | "done";
 
-const STEPS: Array<{ key: StepKey; title: string; copy: string }> = [
+interface StepDef {
+  key: StepKey;
+  index: number;
+  title: string;
+  copy: string;
+}
+
+const STEPS: StepDef[] = [
   {
     key: "intro",
-    title: "1 · The setup",
-    copy: "A repo owner has funded a vault with USDC. Bounties pay out for verifiable GitHub outcomes (report, triage, fix, docs_tests).",
+    index: 1,
+    title: "Vault funded",
+    copy: "Repo owner funded a USDC vault and configured per-kind prices for report, triage, fix, and docs_tests bounties.",
   },
   {
     key: "draft-issue",
-    title: "2 · File the issue",
-    copy: "An agent (Alice) finds a bug. She files the GitHub issue. The issue number `#N` becomes part of her commitment.",
+    index: 2,
+    title: "Issue filed",
+    copy: "An agent finds a bug and files the GitHub issue. The issue number becomes part of the on-chain claim id.",
   },
   {
     key: "commitment",
-    title: "3 · Bind the commitment",
-    copy: "Alice computes `keccak256(agentId, repoId, externalId, salt)` and pastes it into the issue body. This binds the GH author to her wallet via ERC-8004.",
+    index: 3,
+    title: "Commitment bound",
+    copy: "Agent computes keccak256(agentId, repoId, externalId, salt) and pastes the marker into the issue body — binding GH author to wallet via ERC-8004.",
   },
   {
     key: "submit",
-    title: "4 · Submit the claim",
-    copy: "Alice POSTs the claim to the coordinator with her commitment reveal. The coordinator returns a claimId and starts the pipeline.",
+    index: 4,
+    title: "Claim submitted",
+    copy: "Agent POSTs the claim with reveal data; coordinator returns a deterministic claimId and starts the pipeline.",
   },
   {
     key: "fact",
-    title: "5 · DON delivers the fact",
-    copy: "Chainlink Functions (locally simulated) fetches the issue, applies the kind-specific rules from `chainlink/source-core.js`, and returns `(status, mergedBlock, labelMask, ghAuthorBinding)` on chain.",
+    index: 5,
+    title: "DON delivers fact",
+    copy: "Chainlink Functions runs the canonical source script, parses the issue, and returns (status, mergedBlock, labelMask, ghAuthorBinding) on chain.",
   },
   {
     key: "verifiers",
-    title: "6 · Verifiers attest",
-    copy: "Each verifier identity runs the `x502-verify` skill in their local Claude. The skill fetches the issue, applies the kind-specific rubric, and publishes an EAS attestation under the vault's schema for `(claimId, factHash, accept)`. The coordinator's EAS event watcher observes them on-chain until M of N have landed.",
+    index: 6,
+    title: "Verifiers attest",
+    copy: "Each trusted verifier identity runs the x502-verify skill, applies the kind-specific rubric, and publishes an EAS attestation under the vault's schema.",
   },
   {
     key: "payout",
-    title: "7 · Vault settles",
-    copy: "Coordinator submits `BountyVault.payout(...)` with the M attestation UIDs + factHash. The vault re-fetches each attestation by UID, validates schema/revocation/claim binding/trust, and transfers USDC to Alice + a tiny outcome fee to each attester.",
+    index: 7,
+    title: "Vault settles",
+    copy: "Coordinator submits BountyVault.payout with the M attestation UIDs + factHash. Vault validates schema/revocation/claim binding/trust, then pays USDC.",
   },
   {
     key: "done",
-    title: "8 · Paid",
-    copy: "Tx hash visible on Basescan (or local anvil). Alice has the bounty in her wallet, the protocol has a verifiable trail.",
+    index: 8,
+    title: "Paid",
+    copy: "Tx hash is on Basescan, claimant has the bounty, attesters earned the per-verifier outcome fee.",
   },
 ];
 
@@ -59,8 +74,6 @@ export interface CommitmentFormProps {
   repoSlug: string;
   externalId: string;
   recipient: string;
-  /// Already-derived commitment hash; pass `undefined` when inputs are
-  /// incomplete (the form shows a hint instead of a stale value).
   commitment: `0x${string}` | undefined;
   salt: string;
   onSaltChange: (salt: `0x${string}`) => void;
@@ -71,50 +84,127 @@ export function DemoStepper({
   commitmentForm,
 }: {
   current: StepKey;
-  /// When provided AND the active step is `commitment`, the stepper renders
-  /// inline copy/draft helpers so the user never has to manually shuffle
-  /// markers between this app and GitHub.
   commitmentForm?: CommitmentFormProps;
 }) {
   const currentIdx = STEPS.findIndex((s) => s.key === current);
+
   return (
-    <div className="space-y-3">
-      <h2 className="text-xs uppercase tracking-widest text-muted">Demo walkthrough</h2>
-      <ol className="space-y-2">
+    <section className="x502-card p-6 sm:p-7 space-y-5">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="x502-eyebrow">Pipeline</h2>
+        <span className="text-2xs text-text-muted font-mono tabular-nums">
+          {Math.max(currentIdx, 0) + 1} / {STEPS.length}
+        </span>
+      </div>
+
+      <ol className="relative space-y-1">
+        {/* connecting rail */}
+        <div aria-hidden className="absolute left-[15px] top-3 bottom-3 w-px bg-line" />
+
         {STEPS.map((s, i) => {
           const done = i < currentIdx;
           const active = i === currentIdx;
+          const upcoming = i > currentIdx;
           return (
             <li
               key={s.key}
               className={[
-                "rounded border p-3 transition",
-                active
-                  ? "border-accent/60 bg-accent/5"
-                  : done
-                    ? "border-paper/10 opacity-60"
-                    : "border-paper/10 opacity-40",
+                "relative pl-10 pr-2 py-3 rounded-lg transition-colors",
+                active ? "bg-accent/5" : "",
               ].join(" ")}
             >
-              <div className="flex items-baseline justify-between text-sm">
-                <span className="font-semibold">{s.title}</span>
-                {done && <span className="text-xs text-accent">done</span>}
-                {active && <span className="text-xs text-accent animate-pulse">active</span>}
+              <StepDot done={done} active={active} index={s.index} />
+              <div className="space-y-1">
+                <div className="flex items-baseline gap-2">
+                  <span
+                    className={[
+                      "font-medium text-sm",
+                      done
+                        ? "text-text-muted line-through decoration-text-faint/40"
+                        : active
+                          ? "text-text-strong"
+                          : "text-text-muted",
+                    ].join(" ")}
+                  >
+                    {s.title}
+                  </span>
+                  {active && (
+                    <span className="text-2xs uppercase tracking-[0.18em] text-accent font-medium">
+                      active
+                    </span>
+                  )}
+                  {done && (
+                    <span className="text-2xs uppercase tracking-[0.18em] text-success/80 font-medium">
+                      done
+                    </span>
+                  )}
+                </div>
+                <p
+                  className={[
+                    "text-xs leading-relaxed",
+                    upcoming ? "text-text-faint" : "text-text-muted",
+                  ].join(" ")}
+                >
+                  {s.copy}
+                </p>
+                {active && s.key === "commitment" && commitmentForm && (
+                  <CommitmentForm form={commitmentForm} />
+                )}
               </div>
-              <p className="text-xs text-muted leading-5 mt-1">{s.copy}</p>
-              {active && s.key === "commitment" && commitmentForm && (
-                <CommitmentForm form={commitmentForm} />
-              )}
             </li>
           );
         })}
       </ol>
-    </div>
+    </section>
+  );
+}
+
+function StepDot({
+  done,
+  active,
+  index,
+}: {
+  done: boolean;
+  active: boolean;
+  index: number;
+}) {
+  if (done) {
+    return (
+      <span className="absolute left-2 top-3.5 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent text-white shadow-glow">
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          role="img"
+          aria-label="step done"
+        >
+          <title>step done</title>
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      </span>
+    );
+  }
+  if (active) {
+    return (
+      <span className="absolute left-2 top-3.5 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent text-white shadow-glow animate-pulse-ring">
+        <span className="font-mono text-[11px] font-medium">{index}</span>
+      </span>
+    );
+  }
+  return (
+    <span className="absolute left-2 top-3.5 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full border border-line bg-ink-700 text-text-faint">
+      <span className="font-mono text-[11px]">{index}</span>
+    </span>
   );
 }
 
 function CommitmentForm({ form }: { form: CommitmentFormProps }) {
-  const [copied, setCopied] = useState<"none" | "marker" | "wallet">("none");
+  const [copied, setCopied] = useState<"none" | "marker">("none");
 
   const commitmentMarker = form.commitment
     ? `<!-- x502-commitment:${form.commitment} -->`
@@ -130,21 +220,21 @@ function CommitmentForm({ form }: { form: CommitmentFormProps }) {
     ? `https://github.com/${form.repoSlug}/issues/new?title=${encodeURIComponent("[x502] bug: ")}&body=${encodeURIComponent(issueBody)}`
     : undefined;
 
-  const copy = async (text: string, kind: "marker" | "wallet") => {
+  const copy = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      setCopied(kind);
+      setCopied("marker");
       setTimeout(() => setCopied("none"), 1500);
     } catch {
-      /* clipboard API unavailable — user can select manually */
+      /* no clipboard — user can select manually */
     }
   };
 
   return (
-    <div className="pt-3 space-y-3 text-xs">
-      <div className="space-y-1">
+    <div className="mt-4 space-y-3 rounded-lg border border-line bg-ink-800/60 p-4 animate-fade-up">
+      <div className="space-y-1.5">
         <div className="flex items-baseline justify-between">
-          <span className="text-muted">commitment hash</span>
+          <span className="x502-eyebrow">commitment</span>
           <button
             type="button"
             onClick={() => form.onSaltChange(randomSalt())}
@@ -154,44 +244,46 @@ function CommitmentForm({ form }: { form: CommitmentFormProps }) {
           </button>
         </div>
         {form.commitment ? (
-          <code className="block font-mono text-[11px] break-all bg-paper/5 rounded p-2">
+          <code className="block font-mono text-[12px] leading-relaxed text-text-strong break-all">
             {form.commitment}
           </code>
         ) : (
-          <p className="text-muted text-[11px]">fill in repo, issue#, agentId, salt to derive</p>
+          <p className="text-text-muted text-[11px]">
+            fill in repo, issue#, agentId, salt to derive
+          </p>
         )}
       </div>
 
-      <div className="space-y-1">
-        <span className="text-muted">paste these two lines into the issue body</span>
-        <pre className="font-mono text-[10px] break-all bg-paper/5 rounded p-2 whitespace-pre-wrap leading-snug">
+      <div className="space-y-1.5">
+        <span className="x502-eyebrow">issue body markers</span>
+        <pre className="font-mono text-[10.5px] leading-snug bg-ink-900/80 border border-line rounded-md p-2.5 whitespace-pre-wrap break-all text-text-strong">
           {commitmentMarker ?? "<!-- x502-commitment:… -->"}
           {"\n"}
           {walletMarker ?? "<!-- x502:… -->"}
         </pre>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2 pt-1">
           <button
             type="button"
             disabled={!commitmentMarker || !walletMarker}
-            onClick={() => copy(`${commitmentMarker}\n${walletMarker}`, "marker")}
-            className="px-2 py-1 rounded border border-paper/20 hover:border-accent disabled:opacity-30"
+            onClick={() => copy(`${commitmentMarker}\n${walletMarker}`)}
+            className="x502-button-secondary"
           >
-            {copied === "marker" ? "copied!" : "copy markers"}
+            {copied === "marker" ? "copied" : "copy markers"}
           </button>
           {draftUrl && (
             <a
               href={draftUrl}
               target="_blank"
               rel="noreferrer"
-              className="px-2 py-1 rounded border border-accent/40 text-accent hover:bg-accent/10"
+              className="x502-button-secondary border-accent/40 text-accent hover:border-accent"
             >
-              draft issue on GitHub →
+              draft on GitHub →
             </a>
           )}
         </div>
-        <p className="text-muted text-[10px]">
-          GitHub will open with the body pre-filled. Submit the issue, copy its number back into the
-          form, then click "Submit claim".
+        <p className="text-text-muted text-[11px] leading-snug">
+          GitHub opens with the body pre-filled. Submit the issue, paste its number into the form,
+          then submit the claim.
         </p>
       </div>
     </div>
@@ -206,9 +298,6 @@ function randomSalt(): `0x${string}` {
   return s as `0x${string}`;
 }
 
-/// Maps the existing PipelineState onto the stepper's enum. Idle pipelines
-/// resolve to `commitment` because that's where the user is actually doing
-/// work pre-submission — the inline CommitmentForm lives in that step.
 export function stepFromPipeline(pipeline: {
   status: string;
   factReady?: boolean;

--- a/packages/web/components/SepoliaReplay.tsx
+++ b/packages/web/components/SepoliaReplay.tsx
@@ -56,20 +56,47 @@ export function SepoliaReplay() {
     );
   }
 
+  // We deliberately don't render placeholder rows in the live UI — they
+  // are scaffolding for ops to fill in and would otherwise lie about
+  // having a real on-chain proof.
+  const liveRuns = data.runs.filter((r) => r._status !== "placeholder");
+  const vaultZero = /^0x0+$/i.test(data.vault);
+  const factZero = /^0x0+$/i.test(data.factReceiver);
+  const hasLive = liveRuns.length > 0 && !vaultZero && !factZero;
+
+  if (!hasLive) {
+    return (
+      <section className="x502-card p-6 sm:p-7 space-y-3">
+        <div className="flex items-baseline justify-between gap-3">
+          <h2 className="x502-eyebrow">
+            Sepolia proof · {data.network.label} ({data.network.chainId})
+          </h2>
+          <span className="x502-pill">no live runs yet</span>
+        </div>
+        <p className="text-text-muted text-sm leading-relaxed">
+          No recorded payout in{" "}
+          <code className="x502-mono">demo/scripts/sepolia-replay.fixture.json</code> yet. Run a
+          claim through the coordinator and capture the claimId, factHash, attestation UID, and
+          payout tx into the fixture to populate this card.
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section className="x502-card p-6 sm:p-7 space-y-5">
       <div className="flex items-baseline justify-between gap-3">
         <h2 className="x502-eyebrow">
           Sepolia proof · {data.network.label} ({data.network.chainId})
         </h2>
-        <span className="x502-pill">on chain</span>
+        <span className="x502-pill-success">on chain · {liveRuns.length}</span>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <Tile label="Vault" value={shortHash(data.vault)} />
         <Tile label="Fact receiver" value={shortHash(data.factReceiver)} />
       </div>
       <div className="space-y-3">
-        {data.runs.map((r) => (
+        {liveRuns.map((r) => (
           <ReplayRunCard key={r.claimId} run={r} explorer={data.network.explorer} />
         ))}
       </div>

--- a/packages/web/components/SepoliaReplay.tsx
+++ b/packages/web/components/SepoliaReplay.tsx
@@ -39,28 +39,50 @@ export function SepoliaReplay() {
       .catch(() => setError("fixture unavailable"));
   }, []);
 
-  if (error) return <p className="text-xs text-muted">No Sepolia fixture present yet.</p>;
-  if (!data) return <p className="text-xs text-muted">Loading…</p>;
+  if (error) {
+    return (
+      <section className="x502-card p-6 space-y-2">
+        <h2 className="x502-eyebrow">Sepolia proof</h2>
+        <p className="text-text-muted text-sm">No Sepolia fixture present yet.</p>
+      </section>
+    );
+  }
+  if (!data) {
+    return (
+      <section className="x502-card p-6 space-y-2">
+        <h2 className="x502-eyebrow">Sepolia proof</h2>
+        <p className="text-text-muted text-sm">Loading…</p>
+      </section>
+    );
+  }
 
   return (
-    <section className="space-y-4">
-      <h2 className="text-xs uppercase tracking-widest text-muted">
-        Sepolia proof · {data.network.label} ({data.network.chainId})
-      </h2>
-      <div className="text-xs space-y-1">
-        <div className="flex justify-between text-muted">
-          <span>Vault</span>
-          <span className="font-mono">{shortHash(data.vault)}</span>
-        </div>
-        <div className="flex justify-between text-muted">
-          <span>Fact receiver</span>
-          <span className="font-mono">{shortHash(data.factReceiver)}</span>
-        </div>
+    <section className="x502-card p-6 sm:p-7 space-y-5">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="x502-eyebrow">
+          Sepolia proof · {data.network.label} ({data.network.chainId})
+        </h2>
+        <span className="x502-pill">on chain</span>
       </div>
-      {data.runs.map((r) => (
-        <ReplayRunCard key={r.claimId} run={r} explorer={data.network.explorer} />
-      ))}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Tile label="Vault" value={shortHash(data.vault)} />
+        <Tile label="Fact receiver" value={shortHash(data.factReceiver)} />
+      </div>
+      <div className="space-y-3">
+        {data.runs.map((r) => (
+          <ReplayRunCard key={r.claimId} run={r} explorer={data.network.explorer} />
+        ))}
+      </div>
     </section>
+  );
+}
+
+function Tile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-line bg-ink-700/40 p-3.5 space-y-1">
+      <div className="x502-eyebrow">{label}</div>
+      <div className="x502-mono text-text-strong">{value}</div>
+    </div>
   );
 }
 
@@ -70,45 +92,56 @@ function ReplayRunCard({ run, explorer }: { run: ReplayRun; explorer: string }) 
   return (
     <div
       className={[
-        "rounded border p-3 text-xs space-y-2",
-        isPlaceholder ? "border-paper/10 opacity-60" : "border-accent/40 bg-accent/5",
+        "rounded-xl border p-4 space-y-2.5",
+        isPlaceholder ? "border-line bg-ink-700/30 opacity-70" : "border-accent/40 bg-accent/5",
       ].join(" ")}
     >
-      <div className="flex justify-between items-baseline">
-        <span className="font-semibold">
-          {run.kind} · {run.repo} #{run.externalId}
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="font-medium text-text-strong">
+          <span className="font-mono">{run.kind}</span>
+          <span className="text-text-muted"> · {run.repo} </span>
+          <span className="font-mono">#{run.externalId}</span>
         </span>
-        {isPlaceholder && <span className="text-[10px] text-muted">placeholder</span>}
+        {isPlaceholder ? (
+          <span className="x502-pill">placeholder</span>
+        ) : (
+          <span className="x502-pill-success">paid · {run.claimantAmountUsdc} USDC</span>
+        )}
       </div>
-      <div className="flex justify-between text-muted">
-        <span>claimId</span>
-        <span className="font-mono">{shortHash(run.claimId)}</span>
+      <div className="grid grid-cols-2 gap-3">
+        <Row label="claimId" value={shortHash(run.claimId)} mono />
+        <Row label="factHash" value={shortHash(run.factHash)} mono />
       </div>
-      <div className="flex justify-between text-muted">
-        <span>factHash</span>
-        <span className="font-mono">{shortHash(run.factHash)}</span>
-      </div>
-      <div className="flex justify-between">
-        <span className="text-muted">paid</span>
-        <span className="text-accent">{run.claimantAmountUsdc} USDC</span>
-      </div>
-      <div className="flex justify-between text-muted">
-        <span>signers</span>
-        <span>{run.verifierSignatures.map((s) => `#${s.agentId}`).join(" · ")}</span>
-      </div>
+      <Row label="signers" value={run.verifierSignatures.map((s) => `#${s.agentId}`).join(" · ")} />
       {txUrl && (
         <a
           href={txUrl}
           target="_blank"
           rel="noreferrer"
-          className="text-xs text-accent underline break-all"
+          className="block x502-mono x502-link break-all"
         >
-          {run.payoutTx}
+          {run.payoutTx} ↗
         </a>
       )}
     </div>
   );
 }
 
-// re-export so a parent can render it within an existing layout helper.
-export { formatUsdc };
+function Row({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex justify-between text-sm">
+      <span className="text-text-muted">{label}</span>
+      <span className={mono ? "x502-mono text-text-strong" : "text-text-strong"}>{value}</span>
+    </div>
+  );
+}
+
+export { formatUsdc, basescanTx };

--- a/packages/web/components/VerifierTheater.tsx
+++ b/packages/web/components/VerifierTheater.tsx
@@ -37,11 +37,7 @@ export function VerifierTheater({
 }: {
   coordinatorUrl: string;
   claimId: string | undefined;
-  /// (agentId, address) pairs from the demo runtime — used to map an
-  /// observed attester back to the verifier identity for display.
   agents: AgentSpec[];
-  /// Optional. Base URL for an attestation explorer (e.g. attest.org). When
-  /// set, each attested column links to `${easExplorerBase}/${uid}`.
   easExplorerBase?: string;
 }) {
   const [deltas, setDeltas] = useState<Record<string, AttestationDelta>>({});
@@ -50,6 +46,9 @@ export function VerifierTheater({
 
   useEffect(() => {
     if (!claimId) return;
+    setDeltas({});
+    setFact({});
+    setPayoutTx(undefined);
     const sub = subscribeDemoEvents(`${coordinatorUrl}/events`, {
       claimId,
       onEvent: (event) => {
@@ -73,54 +72,105 @@ export function VerifierTheater({
   }, [coordinatorUrl, claimId]);
 
   return (
-    <section className="space-y-3">
-      <h2 className="text-xs uppercase tracking-widest text-muted">Verifier theater</h2>
-      <p className="text-[11px] text-muted leading-snug">
-        Each verifier identity runs the <code>x502-verify</code> skill in their own Claude. Their
-        EAS attestations land here as the coordinator observes them on chain.
-      </p>
-
-      <div className="rounded border border-paper/10 p-3 text-xs space-y-1">
-        <div className="flex justify-between">
-          <span className="text-muted">DON fact</span>
-          <span>
-            {fact.status === undefined ? (
-              <span className="text-muted">awaiting…</span>
-            ) : fact.status === 1 ? (
-              <span className="text-accent">accepted (status=1)</span>
-            ) : (
-              <span className="text-red-400">rejected (status={fact.status})</span>
-            )}
-          </span>
-        </div>
-        {fact.mergedBlock && fact.mergedBlock !== "0" && (
-          <div className="flex justify-between text-muted">
-            <span>mergedBlock</span>
-            <span className="font-mono">{fact.mergedBlock}</span>
-          </div>
-        )}
-        {fact.ghAuthorBinding && (
-          <div className="flex justify-between text-muted">
-            <span>ghAuthorBinding</span>
-            <span className="font-mono">{shortHash(fact.ghAuthorBinding as `0x${string}`)}</span>
-          </div>
-        )}
+    <section className="x502-card p-6 sm:p-7 space-y-5">
+      <div className="space-y-1">
+        <h2 className="x502-eyebrow">Verifier theater</h2>
+        <p className="text-text-muted text-sm leading-relaxed">
+          Each verifier identity runs the <code className="x502-mono">x502-verify</code> skill in
+          their own Claude. EAS attestations land here as the coordinator observes them on chain.
+        </p>
       </div>
 
-      <div className="grid grid-cols-3 gap-2">
+      <FactBlock fact={fact} />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {agentSpecs.map((s) => {
           const agent = agentColumnFromSpec(s, deltas);
-          return <AgentColumnCard key={s.agentId} agent={agent} explorer={easExplorerBase} />;
+          return <AgentCard key={s.agentId} agent={agent} explorer={easExplorerBase} />;
         })}
       </div>
 
       {payoutTx && (
-        <div className="rounded border border-accent/40 bg-accent/5 p-3 text-xs">
-          <span className="text-muted">payout tx </span>
-          <span className="font-mono break-all">{payoutTx}</span>
+        <div className="rounded-xl border border-success/40 bg-success/10 p-4 space-y-1.5 animate-fade-up">
+          <div className="flex items-center justify-between">
+            <span className="text-success font-medium text-sm">Payout settled</span>
+            <span className="x502-pill-success">on chain</span>
+          </div>
+          <a
+            href={`https://sepolia.basescan.org/tx/${payoutTx}`}
+            target="_blank"
+            rel="noreferrer"
+            className="block x502-mono text-success break-all hover:underline"
+          >
+            {payoutTx}
+          </a>
         </div>
       )}
     </section>
+  );
+}
+
+function FactBlock({ fact }: { fact: FactState }) {
+  const empty = fact.status === undefined;
+  return (
+    <div
+      className={[
+        "rounded-xl border p-4 space-y-2.5 transition-colors",
+        empty ? "border-line bg-ink-700/40" : "border-line-strong bg-ink-700/60",
+      ].join(" ")}
+    >
+      <div className="flex items-baseline justify-between">
+        <span className="x502-eyebrow">DON fact</span>
+        <FactBadge fact={fact} />
+      </div>
+      {!empty && fact.mergedBlock && fact.mergedBlock !== "0" && (
+        <Row label="mergedBlock" value={fact.mergedBlock} mono />
+      )}
+      {!empty && fact.ghAuthorBinding && (
+        <Row
+          label="ghAuthorBinding"
+          value={shortHash(fact.ghAuthorBinding as `0x${string}`)}
+          mono
+        />
+      )}
+      {empty && (
+        <p className="text-xs text-text-muted">
+          Awaiting Chainlink Functions response — usually 30–60s on Base Sepolia.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function FactBadge({ fact }: { fact: FactState }) {
+  if (fact.status === undefined) {
+    return (
+      <span className="x502-pill">
+        <span className="h-1.5 w-1.5 rounded-full bg-text-faint animate-pulse" />
+        awaiting
+      </span>
+    );
+  }
+  if (fact.status === 1) {
+    return <span className="x502-pill-success">accepted · status 1</span>;
+  }
+  return <span className="x502-pill-danger">rejected · status {fact.status}</span>;
+}
+
+function Row({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex justify-between text-sm">
+      <span className="text-text-muted">{label}</span>
+      <span className={mono ? "x502-mono text-text-strong" : "text-text-strong"}>{value}</span>
+    </div>
   );
 }
 
@@ -137,42 +187,55 @@ export function agentColumnFromSpec(
   };
 }
 
-function AgentColumnCard({
+function AgentCard({
   agent,
   explorer,
 }: {
   agent: AgentColumn;
   explorer?: string;
 }) {
-  const className =
-    agent.status === "attested" ? "border-accent/60 bg-accent/5" : "border-paper/10 animate-pulse";
+  const attested = agent.status === "attested";
   return (
-    <div className={`rounded border ${className} p-3 text-xs space-y-2`}>
-      <div className="flex justify-between items-baseline">
-        <span className="font-semibold">agent {agent.agentId}</span>
-        <span className={agent.status === "attested" ? "text-accent" : "text-muted"}>
-          {agent.status === "attested" ? "✓ attested" : "waiting…"}
+    <article
+      className={[
+        "rounded-xl border p-4 transition-all duration-200 space-y-2.5",
+        attested
+          ? "border-accent/50 bg-accent/10 shadow-glow animate-fade-up"
+          : "border-line bg-ink-700/40",
+      ].join(" ")}
+    >
+      <div className="flex items-baseline justify-between">
+        <span className="font-medium text-text-strong">
+          agent <span className="font-mono">{agent.agentId}</span>
         </span>
+        {attested ? (
+          <span className="x502-pill-accent">attested</span>
+        ) : (
+          <span className="x502-pill">
+            <span className="h-1.5 w-1.5 rounded-full bg-text-faint animate-pulse" />
+            waiting
+          </span>
+        )}
       </div>
-      <p className="text-[10px] font-mono break-all text-muted">
+      <p className="x502-mono text-text-muted">
         {shortHash(agent.attesterAddress as `0x${string}`)}
       </p>
       {agent.uid && (
-        <p className="text-[10px] font-mono break-all">
+        <p className="x502-mono break-all">
           {explorer ? (
             <a
               href={`${explorer.replace(/\/$/, "")}/${agent.uid}`}
               target="_blank"
               rel="noreferrer"
-              className="text-accent underline"
+              className="x502-link"
             >
-              uid {shortHash(agent.uid as `0x${string}`)}
+              uid {shortHash(agent.uid as `0x${string}`)} ↗
             </a>
           ) : (
-            <span className="text-muted">uid {shortHash(agent.uid as `0x${string}`)}</span>
+            <span className="text-text-muted">uid {shortHash(agent.uid as `0x${string}`)}</span>
           )}
         </p>
       )}
-    </div>
+    </article>
   );
 }

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -1,9 +1,24 @@
 import type { Hex } from "viem";
 
+/// Renders a USDC amount (6-decimal native units) as a `$X.YY…` string.
+///
+/// USDC has 6 decimals on chain, so the per-verifier outcome fee
+/// (`1_000n` = `0.001 USDC`) lived below the cent boundary. The previous
+/// implementation truncated to cents and rendered that fee as `$0.00`,
+/// hiding it from the demo's payout breakdown. We now preserve up to
+/// native precision while trimming trailing zeros past the second decimal,
+/// so `0.05` still reads as `$0.05` (not `$0.050000`) but `0.001`
+/// renders honestly as `$0.001`.
 export function formatUsdc(amount: bigint): string {
-  const dollars = amount / 1_000_000n;
-  const cents = (amount % 1_000_000n) / 10_000n;
-  return `$${dollars}.${cents.toString().padStart(2, "0")}`;
+  const negative = amount < 0n;
+  const abs = negative ? -amount : amount;
+  const dollars = abs / 1_000_000n;
+  const fraction = abs % 1_000_000n;
+  let frac = fraction.toString().padStart(6, "0");
+  // trim trailing zeros, but keep ≥2 digits so whole-cent amounts stay $X.YY
+  frac = frac.replace(/0+$/, "");
+  if (frac.length < 2) frac = frac.padEnd(2, "0");
+  return `${negative ? "-" : ""}$${dollars}.${frac}`;
 }
 
 export function shortHash(h: Hex | string): string {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@x502/shared": "workspace:*",
+    "geist": "^1.7.0",
     "next": "^14.2.18",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -1,17 +1,83 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: ["./app/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {
-        ink: "#0b0b10",
-        paper: "#fafaf6",
-        accent: "#0052ff", // base blue
-        muted: "#6f6f7a",
+        // Surface palette — deep, slightly-blue darks + low-opacity
+        // borders to avoid harsh edges. Tuned so accent colour pops without
+        // having to dial up saturation.
+        ink: {
+          DEFAULT: "#06070d",
+          900: "#06070d",
+          800: "#0a0c14",
+          700: "#0f1117",
+          600: "#161924",
+          500: "#1d2030",
+        },
+        line: {
+          DEFAULT: "rgba(255, 255, 255, 0.06)",
+          strong: "rgba(255, 255, 255, 0.10)",
+          accent: "rgba(91, 141, 255, 0.32)",
+        },
+        text: {
+          strong: "rgba(255, 255, 255, 0.96)",
+          DEFAULT: "rgba(255, 255, 255, 0.78)",
+          muted: "rgba(255, 255, 255, 0.55)",
+          faint: "rgba(255, 255, 255, 0.32)",
+        },
+        accent: {
+          DEFAULT: "#5b8dff",
+          soft: "#80a8ff",
+          glow: "rgba(91, 141, 255, 0.18)",
+          ring: "rgba(91, 141, 255, 0.45)",
+        },
+        success: "#34d399",
+        warning: "#fbbf24",
+        danger: "#f87171",
+        // legacy aliases — keep so any unrefactored components still compile
+        paper: "#fafafa",
+        muted: "rgba(255, 255, 255, 0.55)",
       },
       fontFamily: {
-        mono: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
+        sans: ["var(--font-geist-sans)", "ui-sans-serif", "system-ui", "sans-serif"],
+        mono: ["var(--font-geist-mono)", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
+      },
+      fontSize: {
+        "2xs": ["0.6875rem", { lineHeight: "1rem", letterSpacing: "0.04em" }],
+      },
+      letterSpacing: {
+        tightest: "-0.04em",
+      },
+      boxShadow: {
+        glow: "0 0 0 1px rgba(91,141,255,0.4), 0 0 32px -8px rgba(91,141,255,0.45)",
+        ring: "0 0 0 4px rgba(91,141,255,0.18)",
+        card: "inset 0 1px 0 rgba(255,255,255,0.04)",
+      },
+      backgroundImage: {
+        "grid-line": "linear-gradient(to right, rgba(255,255,255,0.04) 1px, transparent 1px)",
+        "grid-fade":
+          "radial-gradient(800px 400px at 80% -10%, rgba(91,141,255,0.18), transparent 60%)",
+      },
+      animation: {
+        "pulse-ring": "pulse-ring 2.4s cubic-bezier(0.4, 0, 0.6, 1) infinite",
+        "fade-up": "fade-up 0.45s ease-out both",
+        shimmer: "shimmer 2.6s linear infinite",
+      },
+      keyframes: {
+        "pulse-ring": {
+          "0%, 100%": { boxShadow: "0 0 0 0 rgba(91,141,255,0.5)" },
+          "50%": { boxShadow: "0 0 0 8px rgba(91,141,255,0)" },
+        },
+        "fade-up": {
+          from: { opacity: "0", transform: "translateY(6px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        shimmer: {
+          "0%": { backgroundPosition: "-200% 0" },
+          "100%": { backgroundPosition: "200% 0" },
+        },
       },
     },
   },

--- a/packages/web/test/format.test.ts
+++ b/packages/web/test/format.test.ts
@@ -4,13 +4,21 @@ import { basescanTx, formatUsdc, shortHash } from "../lib/format";
 describe("formatUsdc", () => {
   test.each([
     [0n, "$0.00"],
-    [1n, "$0.00"],
+    [1n, "$0.000001"],
+    [1_000n, "$0.001"], // per-verifier outcome fee
     [10_000n, "$0.01"],
+    [20_000n, "$0.02"], // triage bounty
+    [49_000n, "$0.049"], // report claimant amount after fee
+    [50_000n, "$0.05"], // report bounty
     [1_000_000n, "$1.00"],
-    [1_234_567n, "$1.23"],
+    [1_234_567n, "$1.234567"],
     [123_456_789_000_000n, "$123456789.00"],
   ])("formats %s as %s", (amount, expected) => {
     expect(formatUsdc(amount)).toBe(expected);
+  });
+
+  test("renders negative amounts with leading minus", () => {
+    expect(formatUsdc(-49_000n)).toBe("-$0.049");
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 4.12.15
       viem:
         specifier: ^2.21.0
-        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       x402-hono:
         specifier: ^1.2.0
         version: 1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -101,6 +101,9 @@ importers:
       '@x502/shared':
         specifier: workspace:*
         version: link:../shared
+      geist:
+        specifier: ^1.7.0
+        version: 1.7.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       next:
         specifier: ^14.2.18
         version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1008,6 +1011,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -2145,6 +2149,11 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  geist@1.7.0:
+    resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
+    peerDependencies:
+      next: '>=13.2.0'
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -3153,6 +3162,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -3748,11 +3758,11 @@ snapshots:
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
 
-  '@gemini-wallet/core@0.3.2(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@gemini-wallet/core@0.3.2(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -5059,19 +5069,19 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@base-org/account': 2.4.0(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@gemini-wallet/core': 0.3.2(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76))
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      porto: 0.2.35(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5112,11 +5122,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.0(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/query-core': 5.100.1
@@ -6204,6 +6214,10 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  geist@1.7.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      next: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   generator-function@2.0.1: {}
 
   get-caller-file@2.0.5: {}
@@ -6731,21 +6745,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.12.15
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 4.3.6
       zustand: 5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/react-query': 5.100.1(react@18.3.1)
       react: 18.3.1
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+      wagmi: 2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -7348,14 +7362,14 @@ snapshots:
       - supports-color
       - terser
 
-  wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
+  wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.100.1(react@18.3.1)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.1)(@types/react@18.3.28)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 18.3.1
       use-sync-external-store: 1.4.0(react@18.3.1)
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7522,7 +7536,7 @@ snapshots:
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
       viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+      wagmi: 2.19.5(@tanstack/query-core@5.100.1)(@tanstack/react-query@5.100.1(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'


### PR DESCRIPTION
## Summary

Replaces the dense brutalist 3-column demo layout with a hero + 2-column shell that has actual visual hierarchy. Functionally identical — the form still POSTs to the coordinator, the pipeline visualizer still reflects state, the verifier theater still observes EAS events.

- design tokens: rich ink palette + semantic state colors, glow + ring shadows, fade-up + pulse-ring keyframes
- typography: Geist Sans for body / display, Geist Mono for hashes / code, clear type scale, tightest tracking on display
- globals.css: subtle radial accent gradient + faint dot grid backdrop, matte scrollbars, in-palette selection, semantic component classes (.x502-card, .x502-input, .x502-button, .x502-pill, .x502-eyebrow)
- vertical timeline stepper with connecting rail and per-step states (pending outlined / active pulse-ring / done filled+check)
- claim form: bigger inputs with focus rings, tile-grid kind selector, collapsible commitment-binding accordion, payout summary card, pipeline pill in the header
- pipeline visualizer: 4-stage horizontal track instead of the dotted-list step indicator
- verifier theater: agent cards with attestation badges + on-chain UID links, fact accept/reject pill
- sepolia proof: cleaner tile + run-card layout with payout-amount pill
- accessibility: SVG icons get role/aria-label/<title>

## Visual proof

Before/after at 1440 / 768 / 375 captured locally under `demo/.runtime/ralph-screenshots/before-*.png` and `after-*.png` (gitignored).

## Live Base Sepolia E2E from the new UI

Filed a fresh GitHub issue ([skanislav/x502#13](https://github.com/Skanislav/x502/issues/13)) with proper x502 markers and labels, then drove the full pipeline through the new web form:

| Step | Tx |
|------|----|
| Claim submitted via UI form | claimId `0x18e06d3da5572f3a21167c4983ffd77b7f0e23a96e05c8e17c283ff00b861f06` |
| Chainlink Functions fact (status=1) | factHash `0xfdb18441…3467152` |
| EAS attestation (agent 5260) | [tx `0x85ec39a2…d49d3fb`](https://sepolia.basescan.org/tx/0x85ec39a22b512f6adca53f729020f52b474b3ec85bab805b76195e6fdf49d3fb) (UID `0xdd2f701b…0d19a3c`) |
| **Coordinator-driven payout** | [tx `0xa5895670…ddac433`](https://sepolia.basescan.org/tx/0xa58956704407c0bd33dda379229e4e1c96c46489703a024c120792ca9ddac433) — `isPaid==true` |

The watcher caught the live attestation event without needing the runbook's permissionless fallback, which closes the loop on the second of the two operational notes I called out in the parent PR.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint:ts` clean
- [x] `pnpm test:ts` — coordinator / shared / demo / web / chainlink suites all pass
- [x] Visual smoke at 1440 / 768 / 375 (full-page screenshots)
- [x] Real Base Sepolia E2E via the new UI (see table above)

## Notes

- Branched from `fix/base-sepolia-demo-flow`. Targets that branch so the diff against `main` stays focused on protocol changes; once both are merged the UI work lands cleanly on top.
- Mid-loop I had to top up Chainlink Functions subscription #216 with another 2 LINK ([tx `0x82816ef4…1c489`](https://sepolia.basescan.org/tx/0x82816ef497c30ee1624c5bfca0c5c7d6f696a17faf7b03804b1133cceb71c489)) — sequential testing burns through it quickly. The parent PR already flags this as an op note.